### PR TITLE
Fix missing command in PC Setup

### DIFF
--- a/docs/en/platform/turtlebot3/pc_setup.md
+++ b/docs/en/platform/turtlebot3/pc_setup.md
@@ -70,6 +70,7 @@ $ sudo apt-get install ros-kinetic-joy ros-kinetic-teleop-twist-joy ros-kinetic-
 $ cd ~/catkin_ws/src/
 $ git clone https://github.com/ROBOTIS-GIT/turtlebot3_msgs.git
 $ git clone https://github.com/ROBOTIS-GIT/turtlebot3.git
+$ source /opt/ros/kinetic/setup.bash
 $ cd ~/catkin_ws && catkin_make
 ```
 


### PR DESCRIPTION
I propose adding `source /opt/ros/kinetic/setup.bash`, as it appears to be required for `catkin_make` to work.