### PR TITLE
Update OpenCR fw upload method for waffle & waffle pi.

### DIFF
--- a/docs/en/platform/turtlebot3/ros2.md
+++ b/docs/en/platform/turtlebot3/ros2.md
@@ -325,36 +325,72 @@ $ tar -xjf ./opencr_update.tar.bz2
 ```
 
 #### Upload TurtleBot3 ROS 2 firmware to OpenCR.
-```bash
-# Set a port for OpenCR 
-$ export OPENCR_PORT=/dev/ttyACM0
-# Set a model of TurtleBot3 you are using
-$ export OPENCR_MODEL=burger
-$ cd ~/opencr_update && ./update.sh $OPENCR_PORT $OPENCR_MODEL.opencr
-```
 
-If uploading the firmware succeeds, some messages will be displayed in the terminal like below.
-```bash
-aarch64
-arm
-OpenCR Update Start..
-opencr_ld_shell ver 1.0.0
-opencr_ld_main
-[  ] file name   	: burger.opencr
-[  ] file size   	: 168 KB
-[  ] fw_name     	: burger
-[  ] fw_ver      	: V180903R1
-[OK] Open port   	: /dev/ttyACM0
-[  ]
-[  ] Board Name  	: OpenCR R1.0
-[  ] Board Ver   	: 0x17020800
-[  ] Board Rev   	: 0x00000000
-[OK] flash_erase 	: 0.96s
-[OK] flash_write 	: 1.92s
-[OK] CRC Check   	: 10E28C8 10E28C8 , 0.006000 sec
-[OK] Download
-[OK] jump_to_fw
-```
+- TurtleBot3 Burger
+
+  ```bash
+  # Set a port for OpenCR 
+  $ export OPENCR_PORT=/dev/ttyACM0
+  # Set a model of TurtleBot3 you are using
+  $ export OPENCR_MODEL=burger
+  $ cd ~/opencr_update && ./update.sh $OPENCR_PORT $OPENCR_MODEL.opencr
+  ```
+
+  If uploading the firmware succeeds, some messages will be displayed in the terminal like below. Check if the message `jump_to_fw` is displayed!
+  ```bash
+  aarch64
+  arm
+  OpenCR Update Start..
+  opencr_ld_shell ver 1.0.0
+  opencr_ld_main
+  [  ] file name   	: burger.opencr
+  [  ] file size   	: 168 KB
+  [  ] fw_name     	: burger
+  [  ] fw_ver      	: V180903R1
+  [OK] Open port   	: /dev/ttyACM0
+  [  ]
+  [  ] Board Name  	: OpenCR R1.0
+  [  ] Board Ver   	: 0x17020800
+  [  ] Board Rev   	: 0x00000000
+  [OK] flash_erase 	: 0.96s
+  [OK] flash_write 	: 1.92s
+  [OK] CRC Check   	: 10E28C8 10E28C8 , 0.006000 sec
+  [OK] Download
+  [OK] jump_to_fw
+  ```
+
+- TurtleBot3 Waffle or Waffle Pi
+  
+  ```bash
+  # Set a port for OpenCR 
+  $ export OPENCR_PORT=/dev/ttyACM0
+  # Set a model of TurtleBot3 you are using
+  $ export OPENCR_MODEL=waffle
+  $ cd ~/opencr_update && ./update.sh $OPENCR_PORT $OPENCR_MODEL.opencr
+  ``` 
+
+  If uploading the firmware succeeds, some messages will be displayed in the terminal like below. Check if the message `jump_to_fw` is displayed!
+  ```bash
+  aarch64
+  arm
+  OpenCR Update Start..
+  opencr_ld_shell ver 1.0.0
+  opencr_ld_main
+  [  ] file name   	: burger.opencr
+  [  ] file size   	: 168 KB
+  [  ] fw_name     	: burger
+  [  ] fw_ver      	: V180903R1
+  [OK] Open port   	: /dev/ttyACM0
+  [  ]
+  [  ] Board Name  	: OpenCR R1.0
+  [  ] Board Ver   	: 0x17020800
+  [  ] Board Rev   	: 0x00000000
+  [OK] flash_erase 	: 0.96s
+  [OK] flash_write 	: 1.92s
+  [OK] CRC Check   	: 10E28C8 10E28C8 , 0.006000 sec
+  [OK] Download
+  [OK] jump_to_fw
+  ```
 
 Reset OpenCR using RESET button.
 


### PR DESCRIPTION
기존 매뉴얼에서는 burger에 대해서만 명시하고 있어,
ROS1 매뉴얼과 동일하게, waffle & waffle pi에 대한 설명을 추가함.

http://emanual.robotis.com/docs/en/platform/turtlebot3/opencr_setup/#recommended-shell-script