### PR TITLE
Update ex-106+.md

### DIFF
--- a/docs/en/dxl/ex/ex-106+.md
+++ b/docs/en/dxl/ex/ex-106+.md
@@ -385,13 +385,37 @@ If the value is 312, the motor torques to the direction of CW and consumes 2000m
 
 # [How to Assemble](#how-to-assemble)
 
-![](/assets/images/dxl/ax/ax_12a_frame_assembly_02.png)
+## Optional Frames
 
-![](/assets/images/dxl/ax/ax_series_frame_assembly_01.png)
++ FR05-F101 and FR08-X101
 
-![](/assets/images/dxl/ax/ax_series_frame_assembly_02.png)
+  ![](/assets/images/dxl/mx/mx-106+_fr05-f101_fr08-x101.png)
 
-![](/assets/images/dxl/ex/ex-106+_combination.png)
++ FR05-S101
+
+  ![](/assets/images/dxl/mx/mx-106+_fr05-s101.png)
+
++ FR08-B101
+
+  ![](/assets/images/dxl/mx/mx-106+_fr08-b101.png)
+
++ FR08-H101
+
+  ![](/assets/images/dxl/mx/mx-106+_fr08-h101.png)
+
++ FR08-H110 and FR08-D101
+
+  ![](/assets/images/dxl/mx/mx-106+_fr08-h110_fr08-d101.png)
+
+## Horns
+
++ HN05-N102
+
+  ![](/assets/images/dxl/mx/mx-106+_hn05-t101.png)
+
++ HN05-I101
+
+  ![](/assets/images/dxl/rx/rx-64_hn05-i101.png)
 
 # [Maintenance](#maintenance)
 
@@ -408,7 +432,18 @@ If the value is 312, the motor torques to the direction of CW and consumes 2000m
 
 ## [Drawings](#drawings)
 
-![](/assets/images/dxl/ax/ax-18a_dimension.png)
+- `Download` [EX-106R DWG]{: .blank}
+- `Download` [EX-106R PDF]{: .blank}
+- `Download` [EX-106R STEP]{: .blank}
+- `Download` [EX-106R IGES]{: .blank}
+
+{% include en/dxl/485_ttl_connection.md %}
+
+[EX-106R DWG]: http://en.robotis.com/service/download.php?no=113
+[EX-106R PDF]: http://en.robotis.com/service/download.php?no=114
+[EX-106R STEP]: http://en.robotis.com/service/download.php?no=115
+[EX-106R IGES]: http://en.robotis.com/service/download.php?no=116
+
 
 {% include en/dxl/download_center_notice.md %}
 


### PR DESCRIPTION
I found EX-106+ e-manual typo.

Edit 1 )
[3.How to Assemble]
The current images are AX series. I changed them to same as MX-106 e-manual.

Edit2 )
[5.4 Drawings]
Same as above. Added link to EX-106+ files(DWG,PDF,STEP,IGES).