### PR TITLE
Fix open_manipulator_x_rviz.launch.py description

### DIFF
--- a/docs/en/platform/openmanipulator_x/ros2_controller_package.md
+++ b/docs/en/platform/openmanipulator_x/ros2_controller_package.md
@@ -377,7 +377,7 @@ This parameter is descripted on open_manipulator_x.cpp in open_manipulator_x_lib
 Load OpenMANIPULATOR-X on RViz.
 
 ``` bash
-$ ros2 launch open_manipulator_x_description open_manipulator_x_rviz2.launch.py 
+$ ros2 launch open_manipulator_x_description open_manipulator_x_rviz.launch.py 
 ```
 
 {% capture notice_01 %}


### PR DESCRIPTION
When I followed the emanual and launched the `launch.py` file but it was not found. This PR simply fixes the launch file to [`open_manipulator_x_rviz.launch.py`](https://github.com/ROBOTIS-GIT/open_manipulator/blob/ros2/open_manipulator_x_description/launch/open_manipulator_x_rviz.launch.py)