### PR TITLE
Windows Documentation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,12 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.2.3)
+    activesupport (6.0.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+      zeitwerk (~> 2.2)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     colorator (1.1.0)
@@ -19,11 +20,11 @@ GEM
     ffi (1.10.0)
     forwardable-extended (2.6.0)
     gemoji (3.0.0)
-    html-pipeline (2.11.0)
+    html-pipeline (2.12.0)
       activesupport (>= 2)
-      nokogiri (>= 1.10.4)
+      nokogiri (>= 1.4)
     http_parser.rb (0.6.0)
-    i18n (1.6.0)
+    i18n (1.7.0)
       concurrent-ruby (~> 1.0)
     jekyll (3.6.3)
       addressable (~> 2.4)
@@ -72,9 +73,9 @@ GEM
       jekyll-paginate (~> 1.1)
       jekyll-sitemap (~> 1.1)
       jemoji (~> 0.8)
-    minitest (5.11.3)
+    minitest (5.13.0)
     multipart-post (2.0.0)
-    nokogiri (1.10.4)
+    nokogiri (1.10.5)
       mini_portile2 (~> 2.4.0)
     octokit (4.14.0)
       sawyer (~> 0.8.0, >= 0.5.3)
@@ -98,6 +99,7 @@ GEM
     thread_safe (0.3.6)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
+    zeitwerk (2.2.1)
 
 PLATFORMS
   ruby

--- a/docs/en/platform/turtlebot3/bringup.md
+++ b/docs/en/platform/turtlebot3/bringup.md
@@ -124,6 +124,7 @@ process[turtlebot3_diagnostics-3]: started with pid [14200]
 **TIP**: Before executing this command, you have to specify the model name of TurtleBot3. The `${TB3_MODEL}` is the name of the model you are using in `burger`, `waffle`, `waffle_pi`. If you want to permanently set the export settings, please refer to [Export TURTLEBOT3_MODEL][export_turtlebot3_model]{: .popup} page.
 {: .notice--success}
 
+# Ubuntu
 ``` bash
 $ export TURTLEBOT3_MODEL=${TB3_MODEL}
 $ roslaunch turtlebot3_bringup turtlebot3_remote.launch
@@ -134,6 +135,19 @@ Open a new terminal window and enter the below command.
 ```bash
 $ rosrun rviz rviz -d `rospack find turtlebot3_description`/rviz/model.rviz
 ```
+
+# Windows
+``` bash
+> set TURTLEBOT3_MODEL=${TB3_MODEL}
+> roslaunch turtlebot3_bringup turtlebot3_remote.launch
+```
+
+Open a new ROS command window and enter the below command.
+
+```bash
+> rosrun rviz rviz -d "<full path to turtlebot3_description>/rviz/model.rviz"
+```
+
 
 ![](/assets/images/platform/turtlebot3/bringup/run_rviz.jpg)
 

--- a/docs/en/platform/turtlebot3/bringup.md
+++ b/docs/en/platform/turtlebot3/bringup.md
@@ -27,7 +27,7 @@ page_number: 14
 {% endcapture %}
 <div class="notice--warning">{{ notice_01 | markdownify }}</div>
 
-**NOTE**: This instruction was tested on `Ubuntu 16.04` and `ROS Kinetic Kame`.
+**NOTE**: This instruction was tested on `Ubuntu 16.04` and `ROS Kinetic Kame` and on `Windows 10` with `ROS Melodic Morena`.
 {: .notice--info}
 
 ## [Run roscore](#run-roscore)
@@ -42,6 +42,24 @@ $ roscore
 ```
 
 ## [Bringup a TurtleBot3](#bringup-a-turtlebot3)
+
+{% capture notice_01 %}
+Before starting to work with turtlebot3 with a Windows 10 Single Board Computer, you'll need to identify which COM port the lidar and OpenCR board are mounted on. To do this, visit the Device Manager, and add one device at a time to see which COM port each represents. 
+
+Then modify the following files:
+
+`turtlebot3_bringup/launch/turtlebot3_core-win.launch`
+``` xml
+<node pkg="rosserial_python" type="serial_node.py" name="turtlebot3_core" output="screen">
+    <param name="port" value="COMx"/>
+```
+
+`turtlebot3_bringup/launch/turtlebot3_lidar-win.launch`
+``` xml
+ <node pkg="hls_lfcd_lds_driver" type="hlds_laser_publisher" name="turtlebot3_lds" output="screen">
+    <param name="port" value="COMy"/>
+```
+{% endcapture %}
 
 **[TurtleBot]** Bring up basic packages to start TurtleBot3 applications.
 

--- a/docs/en/platform/turtlebot3/bringup.md
+++ b/docs/en/platform/turtlebot3/bringup.md
@@ -43,24 +43,6 @@ $ roscore
 
 ## [Bringup a TurtleBot3](#bringup-a-turtlebot3)
 
-{% capture notice_01 %}
-Before starting to work with turtlebot3 with a Windows 10 Single Board Computer, you'll need to identify which COM port the lidar and OpenCR board are mounted on. To do this, visit the Device Manager, and add one device at a time to see which COM port each represents. 
-
-Then modify the following files:
-
-`turtlebot3_bringup/launch/turtlebot3_core-win.launch`
-``` xml
-<node pkg="rosserial_python" type="serial_node.py" name="turtlebot3_core" output="screen">
-    <param name="port" value="COMx"/>
-```
-
-`turtlebot3_bringup/launch/turtlebot3_lidar-win.launch`
-``` xml
- <node pkg="hls_lfcd_lds_driver" type="hlds_laser_publisher" name="turtlebot3_lds" output="screen">
-    <param name="port" value="COMy"/>
-```
-{% endcapture %}
-
 **[TurtleBot]** Bring up basic packages to start TurtleBot3 applications.
 
 ``` bash

--- a/docs/en/platform/turtlebot3/export_turtlebot3_model.md
+++ b/docs/en/platform/turtlebot3/export_turtlebot3_model.md
@@ -4,7 +4,10 @@ layout: popup
 
 # [Export TURTLEBOT3_MODEL](#export-turtlebot3-model)
 
-TurtleBot3 has three models, `burger`,` waffle`, and `waffle_pi`, so you have to set which model to use before using. To do this, we specify the model to be used with the `export` command.
+TurtleBot3 has three models, `burger`,` waffle`, and `waffle_pi`, so you have to set which model to use before using. 
+
+## Ubuntu
+To do this on Ubuntu, we specify the model to be used with the `export` command.
 
 ```bash
 export TURTLEBOT3_MODEL=burger
@@ -28,3 +31,14 @@ $ gedit ~/.bashrc
 ``` bash
 $ source ~/.bashrc
 ```
+
+## Windows
+While TurtleBot3 has three models, only the `burger` and `waffle` are supported with a Windows 10 compatible single board computer. 
+
+On Windows, use the command `setx` to set the property globally, then restart the command window for the setting to take effect.
+```bash
+setx TURTLEBOT3_MODEL burger
+setx TURTLEBOT3_MODEL waffle
+```
+
+

--- a/docs/en/platform/turtlebot3/getting_started.md
+++ b/docs/en/platform/turtlebot3/getting_started.md
@@ -26,8 +26,8 @@ First of all, collect information from the [Overview][overview], [Notices][notic
 ## [First steps for using TurtleBot3](#first-steps-for-using-turtlebot3)
 When you have enough understanding about TurtleBot3 from above step, here are the software and hardware setups. Be aware that it is a time-saver to set up the SBC and your PC first, rather than assembling the robot. It is recommended to proceed in the following order.
 
-1. [PC Setup][pc_setup]: Install Linux, ROS and application software for TurtleBot3 on your **Remote PC**.
-2. [SBC Setup][sbc_setup]: Install Linux, ROS and hardware related software to control the TurtleBot3 on your **TurtleBot PC**.
+1. [PC Setup][pc_setup]: Install Linux or Windows, ROS and application software for TurtleBot3 on your **Remote PC**.
+2. [SBC Setup][sbc_setup]: Install Linux or Windows, ROS and hardware related software to control the TurtleBot3 on your **TurtleBot PC**.
 3. [OpenCR Setup][opencr_setup]: Upload latest firmware of TurtleBot3 to OpenCR embedded board.
 4. [Hardware Setup][hardware_setup]: TurtleBots3 is delivered as unassembled parts in the box. Follow the instructions to assemble TurtleBot3. Prepared SBC and OpenCR will be mounted on the robot.
 

--- a/docs/en/platform/turtlebot3/opencr_setup.md
+++ b/docs/en/platform/turtlebot3/opencr_setup.md
@@ -31,13 +31,13 @@ page_number: 11
 
 {% capture notice_01 %}
 **NOTE**: You can choose one of methods for uploading firmware. But we highly recommend to use **shell script**. If you need to modify TurtleBot3's firmware, you can use the second method.
-- Method #1: [**Shell Script**](#shell-script), upload the pre-built binary file using the shell script.
+- Method #1: [**Shell Script**](#shell-script), if you are using linux, you can upload the pre-built binary file using the shell script.
 - Method #2: [**Arduino IDE**](#arduino-ide), build the provided source code and upload the generated binary file using the Arduino IDE.
 {% endcapture %}
 
 <div class="notice--info">{{ notice_01 | markdownify }}</div>
 
-#### [(Recommended) Shell Script](#recommended-shell-script)
+#### [Linux Shell Script](#Linux-shell-script)
   
 This instruction was tested on `Ubuntu 16.04`, `Ubuntu Mate`, `Linux Mint` and `Raspbian`. You can use the following command after connecting OpenCR to remote PC (your desktop or laptop PC) or connect OpenCR to your TurtleBot PC (`Intel® Joule™`, `Raspberry Pi 3`) and execute the following command.
 
@@ -67,7 +67,7 @@ When firmware upload is completed, `jump_to_fw` text string will be printed on t
 
 When firmware upload is completed, `jump_to_fw` text string will be printed on the terminal.
 
-#### [(Alternative) Arduino IDE](#alternative-arduino-ide)
+#### [Arduino IDE](#arduino-ide)
 
 **WARNING**: The contents in this chapter corresponds to the `Remote PC` (your desktop or laptop PC) which will control TurtleBot3. Do **NOT** apply this instruction to your TurtleBot3.
 {: .notice--warning}

--- a/docs/en/platform/turtlebot3/pc_setup.md
+++ b/docs/en/platform/turtlebot3/pc_setup.md
@@ -27,10 +27,16 @@ page_number: 7
 **WARNING**: The contents in this chapter corresponds to the `Remote PC` (your desktop or laptop PC) which will control TurtleBot3. Do **NOT** apply this instruction to your TurtleBot3.
 {: .notice--warning}
 
-**NOTE**: This instruction was tested on `Ubuntu 16.04` and `ROS Kinetic Kame`.
+**NOTE**: This instruction was tested on Linux with `Ubuntu 16.04` and `ROS Kinetic Kame`, and Windows with `Windows 10` and ROS `Melodic Moreana`
 {: .notice--info}
 
-### [Install Ubuntu on Remote PC](#install-ubuntu-on-remote)
+Select which Operating System you'd like to use for the remote PC:
+- [Linux][install-linux-on-remote]
+- [Windows][install-windows-on-remote]
+
+
+### [Linux Install Instructions](#install-linux-on-remote)
+#### [Install Ubuntu on Remote PC](#install-ubuntu-on-remote)
 
 Download and install the `Ubuntu 16.04` on the `Remote PC (your desktop or laptop PC)` from the following link.
 
@@ -40,7 +46,7 @@ If you need more help for installing Ubuntu, check out the step-by-step guide fr
 
 - [Install ubuntu desktop](https://www.ubuntu.com/download/desktop/install-ubuntu-desktop)
 
-### [Install ROS on Remote PC](#install-ros-on-remote-pc)
+#### [Install ROS on Remote PC](#install-ros-on-remote-pc)
 
 ![](/assets/images/platform/turtlebot3/logo_ros.png)
 

--- a/docs/en/platform/turtlebot3/pc_setup.md
+++ b/docs/en/platform/turtlebot3/pc_setup.md
@@ -27,16 +27,15 @@ page_number: 7
 **WARNING**: The contents in this chapter corresponds to the `Remote PC` (your desktop or laptop PC) which will control TurtleBot3. Do **NOT** apply this instruction to your TurtleBot3.
 {: .notice--warning}
 
-**NOTE**: This instruction was tested on Linux with `Ubuntu 16.04` and `ROS Kinetic Kame`, and Windows with `Windows 10` and ROS `Melodic Moreana`
+**NOTE**: This instruction was tested on Linux with `Ubuntu 16.04` and `ROS1 Kinetic Kame`, and Windows with `Windows 10` and ROS `ROS1 Melodic Moreana`
 {: .notice--info}
 
 Select which Operating System you'd like to use for the remote PC:
-- [Linux][install-linux-on-remote]
-- [Windows][install-windows-on-remote]
+- [Ubuntu](#install-ubuntu-on-remote)
+- [Windows](#install-windows-10-instructions)
 
 
-### [Linux Install Instructions](#install-linux-on-remote)
-#### [Install Ubuntu on Remote PC](#install-ubuntu-on-remote)
+### [Install Ubuntu on Remote PC](#install-ubuntu-on-remote-pc)
 
 Download and install the `Ubuntu 16.04` on the `Remote PC (your desktop or laptop PC)` from the following link.
 
@@ -125,3 +124,41 @@ $ source ~/.bashrc
 ```
 
 [ubuntu_download_link]: https://www.ubuntu.com/download/alternative-downloads
+
+### [Install Windows 10 Instructions](#install-windows-10-instructions)
+
+If you do not already have `Windows 10` on your Remote PC (Desktop, Laptop or SBC), you can download a trial of Windows 10 IoT Enterprise from the following link:
+- [Download link][windows_download_link]
+
+[windows_download_link]: https://www.microsoft.com/en-us/evalcenter/evaluate-windows-10-enterprise
+
+Please refer to the [ROS Wiki instructions](https://wiki.ros.org/Installation/Windows) for installing ROS on Windows.
+
+#### Setup Turtlebot3 ROS workspace
+``` bash
+mkdir c:\ws\turtlebot3\src
+cd c:\ws\turtlebot3\src
+catkin_init_workspace
+git clone -b melodic-devel https://github.com/ROBOTIS-GIT/turtlebot3_msgs
+git clone -b melodic-devel https://github.com/ROBOTIS-GIT/turtlebot3_simulations
+git clone -b melodic-devel https://github.com/ROBOTIS-GIT/turtlebot3
+git clone -b melodic-devel https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver
+cd c:\ws\turtlebot3
+rosdep update
+rosdep install --from-paths src --ignore-src -r -y
+catkin_make
+devel\setup.bat
+```
+
+### [Network Configuration for Windows](#network-configuration-for-windows)
+To communicate from a Windows 10 system to a remote single board computer (SBC) running on the turtlebot, set the following environment variables:
+
+``` bash
+set ROS_MASTER_URI=http://<IP address of the SBC>:11311
+set ROS_HOSTHANE=<name of the windows computer>
+```
+
+
+
+
+

--- a/docs/en/platform/turtlebot3/sbc_setup.md
+++ b/docs/en/platform/turtlebot3/sbc_setup.md
@@ -28,6 +28,9 @@ page_number: 8
 **NOTE**: We are offering three models of TurtleBot3. TurtleBot3 Burger and Waffle Pi use Raspberry Pi 3 B and B+, and TurtleBot3 Waffle uses Intel Joule 570x. Choose from the following pages according to the SBC used in your model.
 {: .notice--info}
 
+**NOTE**: If you would like to use Windows on your Turtlebot3, you'll need to separately acquire a Windows 10 Enterprise compatible Single Board Computer, and adapt it to the turtlebot power supply.
+{: .notice--info}
+
 ### [Raspberry Pi 3](#raspberry-pi-3)
 
 {% capture info_01 %}
@@ -56,3 +59,17 @@ page_number: 8
 [install_linux_ubuntu_mate]: /docs/en/platform/turtlebot3/raspberry_pi_3_setup/#install-linux-ubuntu-mate
 [install_linux_based_on_raspbian]: /docs/en/platform/turtlebot3/raspberry_pi_3_setup/#install-linux-based-on-raspbian
 [install_ubuntu]: /docs/en/platform/turtlebot3/joule_setup/#install-linux-ubuntu
+
+### [Windows 10 Single board computer](#windows-10-single-board-computer)
+
+1. You can download a trial of Windows 10 IoT Enterprise Long Term Service (LTSC) from the following link:
+   - [Download link][windows_download_link]
+
+   [windows_download_link]: https://www.microsoft.com/en-us/evalcenter/evaluate-windows-10-enterprise
+
+2. Please refer to the [ROS Wiki instructions](https://wiki.ros.org/Installation/Windows) for installing ROS on Windows.
+3. Please install the [CP2102 Driver from SI Labs](https://www.silabs.com/products/development-tools/software/usb-to-uart-bridge-vcp-drivers) in order to communicate with the Lidar.
+
+
+
+

--- a/docs/en/platform/turtlebot3/sbc_setup.md
+++ b/docs/en/platform/turtlebot3/sbc_setup.md
@@ -70,7 +70,7 @@ page_number: 8
 2. Please refer to the [ROS Wiki instructions](https://wiki.ros.org/Installation/Windows) for installing ROS on Windows.
 3. Please install the [CP2102 Driver from SI Labs](https://www.silabs.com/products/development-tools/software/usb-to-uart-bridge-vcp-drivers) in order to communicate with the Lidar.
 
-Before starting to work with turtlebot3 with a Windows 10 Single Board Computer, you'll need to identify which COM port the lidar and OpenCR board are mounted on. To do this, visit the Device Manager, and add one device at a time to see which COM port each represents. 
+Before starting to work with turtlebot3 with a Windows 10 Single Board Computer, you'll need to identify which COM port the lidar and OpenCR board are mounted on. To do this, visit the Windows Device Manager - which you can access by right clicking on the Start Menu icon, and selecting `Device Manager` and locate the COM port associated with the Lidar and OpenCR board.
 
 Then modify the following files:
 

--- a/docs/en/platform/turtlebot3/sbc_setup.md
+++ b/docs/en/platform/turtlebot3/sbc_setup.md
@@ -70,6 +70,23 @@ page_number: 8
 2. Please refer to the [ROS Wiki instructions](https://wiki.ros.org/Installation/Windows) for installing ROS on Windows.
 3. Please install the [CP2102 Driver from SI Labs](https://www.silabs.com/products/development-tools/software/usb-to-uart-bridge-vcp-drivers) in order to communicate with the Lidar.
 
+Before starting to work with turtlebot3 with a Windows 10 Single Board Computer, you'll need to identify which COM port the lidar and OpenCR board are mounted on. To do this, visit the Device Manager, and add one device at a time to see which COM port each represents. 
+
+Then modify the following files:
+
+`turtlebot3_bringup/launch/turtlebot3_core-win.launch`
+``` xml
+<node pkg="rosserial_python" type="serial_node.py" name="turtlebot3_core" output="screen">
+    <param name="port" value="COMx"/>
+```
+
+`turtlebot3_bringup/launch/turtlebot3_lidar-win.launch`
+``` xml
+ <node pkg="hls_lfcd_lds_driver" type="hlds_laser_publisher" name="turtlebot3_lds" output="screen">
+    <param name="port" value="COMy"/>
+```
+
+
 
 
 

--- a/docs/en/platform/turtlebot3/slam.md
+++ b/docs/en/platform/turtlebot3/slam.md
@@ -22,7 +22,7 @@ page_number: 20
 
 {% capture notice_01 %}
 **NOTE**: 
-- This instructions were tested on `Ubuntu 16.04` and `ROS Kinetic Kame`.
+- This instructions were tested on `Ubuntu 16.04` and `ROS Kinetic Kame` and on `Windows 10` with `ROS Melodic Morena`
 - This instructions are supposed to be running on the remote PC. Please run the instructions below on your **Remote PC**.
 - The terminal application can be found with the Ubuntu search icon on the top left corner of the screen. The shortcut key for running the terminal is `Ctrl`-`Alt`-`T`.
 - Make sure to run the [Bringup](/docs/en/platform/turtlebot3/bringup/#bringup) instruction before use of the instruction.
@@ -80,6 +80,14 @@ $ roslaunch turtlebot3_bringup turtlebot3_robot.launch
 **[Remote PC]** Open a new terminal and launch the SLAM file.
 
 **TIP**: Before executing this command, you have to specify the model name of TurtleBot3. The `${TB3_MODEL}` is the name of the model you are using in `burger`, `waffle`, `waffle_pi`. If you want to permanently set the export settings, please refer to [Export TURTLEBOT3_MODEL][export_turtlebot3_model]{: .popup} page.
+
+{% capture slam_tip %}
+**TIP**: When running these commands on `Windows 10`,  replace `export TURTLEBOT3_MODEL=${TB3_MODEL}` with `set TURTLEBOT3_MODEL=${TB3_MODEL}` like this:
+``` bash
+$ set TURTLEBOT3_MODEL=burger
+```
+{% endcapture %}
+
 {: .notice--success}
 
 ``` bash
@@ -104,6 +112,7 @@ $ roslaunch turtlebot3_slam turtlebot3_slam.launch slam_methods:=gmapping
 **NOTE**: Support for various SLAM methods
 - TurtleBot3 supports Gmapping, Cartographer, Hector, and Karto among various SLAM methods. You can do this by changing the `slam_methods:=xxxxx` option.
 - The `slam_methods` options include `gmapping`, `cartographer`, `hector`, `karto`, `frontier_exploration`, and you can choose one of them.
+- For Windows 10, Google Cartographer has been enabled. OpenKarto is coming soon.
 - For example, to use Karto, you can use the following:
 - $ roslaunch turtlebot3_slam turtlebot3_slam.launch slam_methods:=karto
 {% endcapture %}
@@ -112,22 +121,26 @@ $ roslaunch turtlebot3_slam turtlebot3_slam.launch slam_methods:=gmapping
 {% capture notice_04 %}
 **NOTE**: Install dependency packages for SLAM packages
 - For `Gmapping`:
-- Packages related to Gmapping have already been installed on [PC Setup](/docs/en/platform/turtlebot3/pc_setup/#install-dependent-ros-packages) page.
+  - Packages related to Gmapping have already been installed on [PC Setup](/docs/en/platform/turtlebot3/pc_setup/#install-dependent-ros-packages) page.
 - For `Cartographer`:
-- sudo apt-get install ros-kinetic-cartographer ros-kinetic-cartographer-ros ros-kinetic-cartographer-ros-msgs ros-kinetic-cartographer-rviz
+  - Ubuntu
+    - sudo apt-get install ros-kinetic-cartographer ros-kinetic-cartographer-ros ros-kinetic-cartographer-ros-msgs ros-kinetic-cartographer-rviz
+  - Windows
+    - choco upgrade ros-melodic-cartographer_ros -y
 - For `Hector Mapping`:
-- sudo apt-get install ros-kinetic-hector-mapping
+  - sudo apt-get install ros-kinetic-hector-mapping
 - For `Karto`:
-- sudo apt-get install ros-kinetic-slam-karto
+  - sudo apt-get install ros-kinetic-slam-karto
 - For `Frontier Exploration`:
 - Frontier Exploration uses gmapping, and the following packages should be installed.
-- sudo apt-get install ros-kinetic-frontier-exploration ros-kinetic-navigation-stage
+  - sudo apt-get install ros-kinetic-frontier-exploration ros-kinetic-navigation-stage
 {% endcapture %}
 <div class="notice--info">{{ notice_04 | markdownify }}</div>
 
 **TIP**: We tested on cartographer version 0.3.0. The Cartographer package developed by Google supports 0.3.0 version in ROS Melodic, but 0.2.0 version in ROS Kinetic. So if you need to work on ROS Kinetic, instead of downloading the binaries files, you should download and build the source code as follows. Please refer to [official wiki page](https://google-cartographer-ros.readthedocs.io/en/latest/#building-installation) for more detailed installation instructions.
 {: .notice--success}
 
+### Ubuntu
 ```sh
 $ sudo apt-get install ninja-build libceres-dev libprotobuf-dev protobuf-compiler libprotoc-dev
 $ cd ~/catkin_ws/src
@@ -143,6 +156,13 @@ $ catkin_make_isolated --install --use-ninja
 ```sh
 $ source ~/catkin_ws/install_isolated/setup.bash
 $ roslaunch turtlebot3_slam turtlebot3_slam.launch slam_methods:=cartographer
+```
+
+### Windows
+``` bash
+c:\ws\turtlebot3\devel\setup.bat
+set TURTLEBOT3_MODEL=waffle
+roslaunch turtlebot3_gazebo turtlebot3_gazebo_cartographer_demo.launch
 ```
 
 ## [Run Teleoperation Node](#run-teleoperation-node)

--- a/docs/en/platform/turtlebot3/slam.md
+++ b/docs/en/platform/turtlebot3/slam.md
@@ -122,6 +122,7 @@ $ roslaunch turtlebot3_slam turtlebot3_slam.launch slam_methods:=gmapping
 **NOTE**: Install dependency packages for SLAM packages
 - For `Gmapping`:
   - Packages related to Gmapping have already been installed on [PC Setup](/docs/en/platform/turtlebot3/pc_setup/#install-dependent-ros-packages) page.
+  - Gmapping has not been enabled on Windows
 - For `Cartographer`:
   - Ubuntu
     - sudo apt-get install ros-kinetic-cartographer ros-kinetic-cartographer-ros ros-kinetic-cartographer-ros-msgs ros-kinetic-cartographer-rviz
@@ -129,10 +130,13 @@ $ roslaunch turtlebot3_slam turtlebot3_slam.launch slam_methods:=gmapping
     - choco upgrade ros-melodic-cartographer_ros -y
 - For `Hector Mapping`:
   - sudo apt-get install ros-kinetic-hector-mapping
+  - Hector Mapping has not been enabled on Windows
 - For `Karto`:
   - sudo apt-get install ros-kinetic-slam-karto
+  - Coming soon on Windows
 - For `Frontier Exploration`:
-- Frontier Exploration uses gmapping, and the following packages should be installed.
+  - Frontier Exploration uses gmapping, and the following packages should be installed.
+  - Frontier Exploration has not been enabled on Windows
   - sudo apt-get install ros-kinetic-frontier-exploration ros-kinetic-navigation-stage
 {% endcapture %}
 <div class="notice--info">{{ notice_04 | markdownify }}</div>
@@ -140,7 +144,7 @@ $ roslaunch turtlebot3_slam turtlebot3_slam.launch slam_methods:=gmapping
 **TIP**: We tested on cartographer version 0.3.0. The Cartographer package developed by Google supports 0.3.0 version in ROS Melodic, but 0.2.0 version in ROS Kinetic. So if you need to work on ROS Kinetic, instead of downloading the binaries files, you should download and build the source code as follows. Please refer to [official wiki page](https://google-cartographer-ros.readthedocs.io/en/latest/#building-installation) for more detailed installation instructions.
 {: .notice--success}
 
-### Ubuntu
+*Ubuntu*
 ```sh
 $ sudo apt-get install ninja-build libceres-dev libprotobuf-dev protobuf-compiler libprotoc-dev
 $ cd ~/catkin_ws/src
@@ -158,8 +162,8 @@ $ source ~/catkin_ws/install_isolated/setup.bash
 $ roslaunch turtlebot3_slam turtlebot3_slam.launch slam_methods:=cartographer
 ```
 
-### Windows
-``` bash
+*Windows*
+```
 c:\ws\turtlebot3\devel\setup.bat
 set TURTLEBOT3_MODEL=waffle
 roslaunch turtlebot3_gazebo turtlebot3_gazebo_cartographer_demo.launch
@@ -169,9 +173,16 @@ roslaunch turtlebot3_gazebo turtlebot3_gazebo_cartographer_demo.launch
 
 **[Remote PC]** Open a new terminal and run the teleoperation node. The following command allows the user to control the robot to perform SLAM operation manually. It is important to avoid vigorous movements such as changing the speed too quickly or rotating too fast. When building a map using the robot, the robot should scan every corner of the environment to be measured. It requires some experiences to build a clean map, so let’s practice SLAM multiple times to build up know how. The mapping process is shown in figure below.
 
+*Ubuntu*
 ``` bash
 $ export TURTLEBOT3_MODEL=${TB3_MODEL}
 $ roslaunch turtlebot3_teleop turtlebot3_teleop_key.launch
+```
+
+*Windows*
+``` bash
+> set TURTLEBOT3_MODEL=waffle
+> roslaunch turtlebot3_teleop turtlebot3_teleop_key.launch
 ```
 
 ``` bash
@@ -241,11 +252,17 @@ _**angularUpdate**_
 
 **[Remote PC]** Now that you have all the work done, let's run the `map_saver` node to create a map file. The map is drawn based on the robot's odometry, tf information, and scan information of the sensor when the robot moves. These data can be seen in the RViz from the previous example video. The created map is saved in the directory in which `map_saver` is runnig. Unless you specify the file name, it is stored as `map.pgm` and `map.yaml` file which contains map information.
 
+*Ubuntu*
 ``` bash
 $ rosrun map_server map_saver -f ~/map
 ```
 
-The `-f` option refers to the folder and file name where the map file is saved. If `~/map` is used as an option, `map.pgm` and `map.yaml` will be saved in the map folder of user’s home folder `~/` ($HOME directory : `/home/<username>`).
+*Windows*
+``` bash
+> rosrun map_server map_saver -f %USERPROFILE%\map
+```
+
+The `-f` option refers to the folder and file name where the map file is saved. If `~/map` is used as an option, `map.pgm` and `map.yaml` will be saved in the map folder of user’s home folder `~/` ($HOME directory : `/home/<username>`). On Windows, the user directory is stored in an environment variable `%USERPROFILE%`
 
 ## [Map](#map)
 

--- a/docs/en/platform/turtlebot3/specifications.md
+++ b/docs/en/platform/turtlebot3/specifications.md
@@ -81,6 +81,10 @@ page_number: 4
   - TurtleBot3 Burger, Waffle Pi (Applied from products shipped in 2019)
 - [Intel® Joule™ 570x](http://ark.intel.com/products/96414/Intel-Joule-570x-Developer-Kit)
   - TurtleBot3 Waffle
+- [Latte Panda Alpha™ by DF Robot](https://www.dfrobot.com/product-1727.html)
+  - Latte Panda Alpha™ by DF Robot
+  - For use with ROS on Windows
+
 
 ### [Sensors](#sensors)
 
@@ -90,6 +94,9 @@ page_number: 4
   - TurtleBot3 Waffle
 - [The Raspberry Pi Camera Module v2.1](https://www.raspberrypi.org/products/camera-module-v2/)
   - TurtleBot3 Waffle Pi
+- [Microsoft Azure Kinect DK](https://azure.microsoft.com/en-us/services/kinect-dk/)
+  - For use with the Latte Panda Alpha™ by DF Robot
+
 
 ### [Embedded Board](#Embedded-board)
 

--- a/docs/en/platform/turtlebot3/specifications.md
+++ b/docs/en/platform/turtlebot3/specifications.md
@@ -81,9 +81,6 @@ page_number: 4
   - TurtleBot3 Burger, Waffle Pi (Applied from products shipped in 2019)
 - [Intel® Joule™ 570x](http://ark.intel.com/products/96414/Intel-Joule-570x-Developer-Kit)
   - TurtleBot3 Waffle
-- [Latte Panda Alpha™ by DF Robot](https://www.dfrobot.com/product-1727.html)
-  - Latte Panda Alpha™ by DF Robot
-  - For use with ROS on Windows
 
 
 ### [Sensors](#sensors)
@@ -94,8 +91,6 @@ page_number: 4
   - TurtleBot3 Waffle
 - [The Raspberry Pi Camera Module v2.1](https://www.raspberrypi.org/products/camera-module-v2/)
   - TurtleBot3 Waffle Pi
-- [Microsoft Azure Kinect DK](https://azure.microsoft.com/en-us/services/kinect-dk/)
-  - For use with the Latte Panda Alpha™ by DF Robot
 
 
 ### [Embedded Board](#Embedded-board)

--- a/docs/en/platform/turtlebot3/teleoperation.md
+++ b/docs/en/platform/turtlebot3/teleoperation.md
@@ -26,7 +26,7 @@ page_number: 17
 
 {% capture notice_01 %}
 **NOTE**: 
-- This instruction was tested on `Ubuntu 16.04` and `ROS Kinetic Kame`.
+- This instruction was tested on `Ubuntu 16.04` with `ROS Kinetic Kame` and `Windows 10` with `ROS Melodic`
 - This examples are supposed to be running on the remote PC. Follow the instruction on your **Remote PC**.
 {% endcapture %}
 <div class="notice--info">{{ notice_01 | markdownify }}</div>
@@ -51,9 +51,16 @@ The contents in e-Manual may differ from contents of a provided video in e-Manau
 
 **[Remote PC]** Launch `turtlebot3_teleop_key` node for simple teleoperation test.
 
+# Ubuntu
 ``` bash
 $ export TURTLEBOT3_MODEL=%{TB3_MODEL}
 $ roslaunch turtlebot3_teleop turtlebot3_teleop_key.launch
+```
+
+# Windows
+``` bash
+> set TURTLEBOT3_MODEL=%{TB3_MODEL}
+> roslaunch turtlebot3_teleop turtlebot3_teleop_key.launch
 ```
 
 If the node is successfully launched, the following instruction will be appeared to the terminal window.
@@ -73,13 +80,21 @@ If the node is successfully launched, the following instruction will be appeared
   CTRL-C to quit
 ```
 
-### [RC100](#rc100)
+# Windows Joystick Instructions
+The Windows implementation of the Joystick control uses the [Open Source Simple DirectMedia Layer](https://www.libsdl.org/), which supports many tethered and wireless joysticks. The Joystick driver is currently (As of January 2020) deployed as a source package, which you need to clone into your catkin workspace.
+
+``` bash
+> git clone -b init_windows https://github.com/ms-iot/joystick_drivers
+```
+
+# Ubuntu Joystick Instructions
+## [RC100](#rc100)
 
 The settings for [ROBOTIS RC-100B][rc100] controller is included in the OpenCR firmware for TurtleBot3 Burger, Waffle and Waffle Pi. This controller can be used with the Bluetooth module [BT410][bt410]. The TurtleBot3 Waffle Pi includes this controller and Bluetooth modules. When using RC-100, it is not necessary to execute a specific node because `turtlebot_core` node creates a `/cmd_vel` topic in the firmware directly connected to OpeCR.
 
 ![](/assets/images/platform/turtlebot3/example/rc100b_with_bt410.png)
 
-### [PS3 Joystick](#ps3-joystick)
+## [PS3 Joystick](#ps3-joystick)
 
 **[Remote PC]** Connect PS3 Joystick to the remote PC via Bluetooth or with USB cable.
 
@@ -95,7 +110,7 @@ $ sudo apt-get install ros-kinetic-joy ros-kinetic-joystick-drivers ros-kinetic-
 $ roslaunch teleop_twist_joy teleop.launch
 ```
 
-### [XBOX 360 Joystick](#xbox-360-joystick)
+## [XBOX 360 Joystick](#xbox-360-joystick)
 
 **[Remote PC]** Connect XBOX 360 Joystick to the remote PC with Wireless Adapter or USB cable.
 
@@ -112,7 +127,7 @@ $ sudo xboxdrv --silent
 $ roslaunch teleop_twist_joy teleop.launch
 ```
 
-### [Wii Remote](#wii-remote)
+## [Wii Remote](#wii-remote)
 
 **[Remote PC]** Connect Wii remote to the remote PC via Bluetooth.
 
@@ -135,11 +150,11 @@ $ rosrun wiimote wiimote_node
 $ rosrun wiimote teleop_wiimote
 ```
 
-### [Nunchuk](#nunchuk)
+## [Nunchuk](#nunchuk)
 
 (TODO)
 
-### [Android App](#android-app)
+## [Android App](#android-app)
 
 Download [ROS CONTROL][ros_control] and run the application.
 
@@ -154,7 +169,7 @@ Then, you can check state of node and topic connection by `rqt_graph` commands
 
 ![](/assets/images/platform/turtlebot3/example/ros_control_graph.png)
 
-### [LEAP Motion](#leap-motion)
+## [LEAP Motion](#leap-motion)
 
 **[Remote PC]** Connect LEAP motion to the remote PC via Bluetooth.
 
@@ -175,7 +190,7 @@ $ git clone git@github.com:warp1337/rosleapmotion.git
 $ rosrun leap_motion sender.py
 ```
 
-### [Myo](#myo)
+## [Myo](#myo)
 
 We are developing its contents ! 
 {: .notice--info}
@@ -186,3 +201,4 @@ We are developing its contents !
 [ros_control]: https://play.google.com/store/apps/details?id=com.robotca.ControlApp
 [leap_setup]: https://www.leapmotion.com/setup
 [leap_sdk]: https://developer.leapmotion.com/get-started/
+

--- a/docs/en/platform/turtlebot3/tensorflow.md
+++ b/docs/en/platform/turtlebot3/tensorflow.md
@@ -50,3 +50,6 @@ $ cd ~/catkin_ws/src/
 $ git clone https://github.com/ROBOTIS-GIT/turtlebot3_simulations.git
 $ cd ~/catkin_ws && catkin_make
 ```
+
+# Windows Machine Learning
+Turtlebot3 with ROS on Windows can use the Windows ML ROS node. Windows ML is an extension to DirectX which enables low level hardware independent computer vision scenarios. For more information on using Windows ML, please visit the [WinML ROS Node documentation](https://aka.ms/ros_winml).

--- a/docs/en/platform/turtlebot3/topic_monitor.md
+++ b/docs/en/platform/turtlebot3/topic_monitor.md
@@ -27,7 +27,7 @@ page_number: 16
 
 {% capture notice_01 %}
 **NOTE**: 
-- This instructions were tested on `Ubuntu 16.04` and `ROS Kinetic Kame`.
+- This instructions were tested on `Ubuntu 16.04` with `ROS Kinetic Kame` and `Windows 10` with `ROS Melodic`
 - This instructions are supposed to be running on the remote PC. Please run the instructions below on your **Remote PC**.
 - Make sure to run the [Bringup](/docs/en/platform/turtlebot3/bringup/#bringup) instructions before use of the instruction
 {% endcapture %}


### PR DESCRIPTION
This change adds ROS1 on Windows documentation to the Turtlebot3 emanual. An attempt was made to minimize the amount of Windows and Ubuntu specific documentation. Not all codepaths were validated on Windows, but those that were have been marked as such.