### PR TITLE
Typo and wording change

### DIFF
--- a/docs/en/parts/interface/u2d2_power_hub.md
+++ b/docs/en/parts/interface/u2d2_power_hub.md
@@ -48,7 +48,7 @@ Combined with U2D2, it can supply various kinds of external power supply to supp
 
     ![](/assets/images/parts/interface/u2d2_power_hub/u2d2_phb_07.jpg)
 
-3. Connect `U2D2` and `U2D2 Power Hub Boar`d with 3P or 4P cables (Both 3P and 4P cables can be connected at the same time).
+3. Connect `U2D2` and `U2D2 Power Hub Board` with 3P or 4P cables (Both 3P and 4P cables can be connected at the same time).
 
     ![](/assets/images/parts/interface/u2d2_power_hub/u2d2_phb_03.jpg)
 
@@ -62,7 +62,7 @@ Combined with U2D2, it can supply various kinds of external power supply to supp
 
 6. Connect power to `U2D2 Power Hub Board`.
 
-    **DANGER** : Do NOT use both power inputs at the same time. Select ONLY one of the power source to connect.
+    **DANGER** : Do NOT use multiple power inputs at the same time. Select ONLY one of the power source to connect.
     {: .notice--danger}
 
     **WARNING** : Check the Recommended Voltage for DYNAMIXEL before supplying the power.

--- a/docs/en/software/dynamixel/dynamixel_wizard2.md
+++ b/docs/en/software/dynamixel/dynamixel_wizard2.md
@@ -236,7 +236,7 @@ Detailed packet data can be loaded by selecting a packet in the packet history.
 
 4. Select `Goal Position` or `Goal Velocity` item in the control table in the middle column.
 
-    **NOTE**: Read a contorl table of your DYNAMIXEL as the item can be different depending on a model and Operation Mode of DYNAMIXEL. 
+    **NOTE**: Read the control table of your DYNAMIXEL as the item can be different depending on the model and Operating Mode of the DYNAMIXEL. 
     {: .notice}
 
     ![](/assets/images/sw/dynamixel/wizard2/wizard2_004.png)     


### PR DESCRIPTION
Line#51 fixed typo "Boar_d" 
Line# 65 updated wording- changed "both power inputs" to "multiple power inputs". The word "both" is not correct because there are three power inputs including the terminal block.