### PR TITLE
ROS 2: fix install error

### DIFF
--- a/docs/en/platform/turtlebot3/ros2_setup.md
+++ b/docs/en/platform/turtlebot3/ros2_setup.md
@@ -65,7 +65,7 @@ $ sudo apt install -y \
     python3-sphinx
 # Install Gazebo9
 $ curl -sSL http://get.gazebosim.org | sh
-$ sudo apt install ros-dashing-gazebo-*
+$ sudo apt install ros-dashing-gazebo-pkgs
 # Install Cartographer
 $ sudo apt install ros-dashing-cartographer
 $ sudo apt install ros-dashing-cartographer-ros

--- a/docs/en/platform/turtlebot3/ros2_setup.md
+++ b/docs/en/platform/turtlebot3/ros2_setup.md
@@ -65,7 +65,7 @@ $ sudo apt install -y \
     python3-sphinx
 # Install Gazebo9
 $ curl -sSL http://get.gazebosim.org | sh
-$ sudo apt install ros-dashing-gazebo-pkgs
+$ sudo apt install ros-dashing-gazebo-ros-pkgs
 # Install Cartographer
 $ sudo apt install ros-dashing-cartographer
 $ sudo apt install ros-dashing-cartographer-ros


### PR DESCRIPTION
`ros-dashing-gazebo-pkgs` installs all the packages needed for Gazebo simulation in ROS 2 Dashing.

Installing `ros-dashing-gazebo-*` results in an error as it tries to install `ros-dashing-gazebo-dev` which apparently has an incompatible dependency on `libgazebo9-dev`.

![image](https://user-images.githubusercontent.com/6248219/81558423-eb905d00-938d-11ea-9305-2cf68afb81a2.png)
