### PR TITLE
fix ros dashing gazebo install

### DIFF
--- a/docs/en/platform/turtlebot3/ros2_setup.md
+++ b/docs/en/platform/turtlebot3/ros2_setup.md
@@ -65,7 +65,9 @@ $ sudo apt install -y \
     python3-sphinx
 # Install Gazebo9
 $ curl -sSL http://get.gazebosim.org | sh
-$ sudo apt install ros-dashing-gazebo-*
+$ sudo apt remove gazebo11 libgazebo11-dev
+$ sudo apt install gazebo9 libgazebo9-dev
+$ sudo apt install ros-dashing-gazebo-ros-pkgs
 # Install Cartographer
 $ sudo apt install ros-dashing-cartographer
 $ sudo apt install ros-dashing-cartographer-ros


### PR DESCRIPTION
Since the release of Eloquent (I suppose), the script at `http://get.gazebosim.org` installs Gazebo 11 on Ubuntu Bionic, however ROS 2 Dashing packages have a dependency on Gazebo 9.

For the install to work, one must, after the `curl -sSL http://get.gazebosim.org | sh` command, run
```
sudo apt remove gazebo11 libgazebo11-dev
sudo apt install gazebo9 libgazebo9-dev
```
And then, one can install Gazebo ROS packages following official directions:
```
sudo apt install ros-dashing-gazebo-ros-pkgs
```