### PR TITLE
typo fix

### DIFF
--- a/docs/en/platform/turtlebot3/pc_setup.md
+++ b/docs/en/platform/turtlebot3/pc_setup.md
@@ -158,7 +158,7 @@ To communicate from a Windows 10 system to a remote single board computer (SBC) 
 
 ``` bash
 > set ROS_MASTER_URI=http://<IP address of the SBC>:11311
-> set ROS_HOSTHANE=<name of the windows computer>
+> set ROS_HOSTNAME=<name of the windows computer>
 ```
 
 


### PR DESCRIPTION
@ooeygui Should we set the IP of the TB3 SBC(UP2) as a MASTER_URI and Remote PC as a Host while setting the MASTER_URI as a Remote PC  in the Remote PC network configuration?