### PR TITLE
name of ubuntu and ros distro fixed

### DIFF
--- a/docs/en/platform/manipulator_h/manipulator_ros_programming.md
+++ b/docs/en/platform/manipulator_h/manipulator_ros_programming.md
@@ -19,7 +19,7 @@ page_number: 6
 
 ## [PC Setup](#pc-setup)
 
-- The ROBOTIS manipulator ROS program is based on **Linux Ununtu 16.04** OS and **ROS Kenitic Kame**.
+- The ROBOTIS manipulator ROS program is based on **Linux Ubuntu 16.04** OS and **ROS Kenetic Kame**.
 
 ### [Install Ubuntu on PC](#install-ubuntu-on-pc)
 


### PR DESCRIPTION
fixing the name of ubuntu and the Ros disto. From Ununtu to Ubuntu, and from Kenitic to Kinetic.