### PR TITLE
opencr_firmware_update

### DIFF
--- a/docs/en/platform/turtlebot3/opencr_setup.md
+++ b/docs/en/platform/turtlebot3/opencr_setup.md
@@ -44,6 +44,14 @@ page_number: 11
 
 This instruction was tested on `Ubuntu 16.04`, `Ubuntu Mate`, `Linux Mint` and `Raspbian`. You can use the following command after connecting OpenCR to remote PC (your desktop or laptop PC) or connect OpenCR to your TurtleBot PC (`Intel® Joule™`, `Raspberry Pi 3`) and execute the following command.
 
+Please make sure that `libc6:armhf` is installed to run the OpenCR firmware updater for Raspberry Pi.
+
+```bash
+$ sudo dpkg --add-architecture armhf
+$ sudo apt-get update
+$ sudo apt-get install libc6:armhf
+```
+
 - TurtleBot3 Burger
 
   ``` bash

--- a/docs/en/platform/turtlebot3/opencr_setup.md
+++ b/docs/en/platform/turtlebot3/opencr_setup.md
@@ -44,7 +44,7 @@ page_number: 11
 
 This instruction was tested on `Ubuntu 16.04`, `Ubuntu Mate`, `Linux Mint` and `Raspbian`. You can use the following command after connecting OpenCR to remote PC (your desktop or laptop PC) or connect OpenCR to your TurtleBot PC (`Intel® Joule™`, `Raspberry Pi 3`) and execute the following command.
 
-Please make sure that `libc6:armhf` is installed to run the OpenCR firmware updater for Raspberry Pi.
+Please make sure that `libc6:armhf` is installed to run the OpenCR firmware updater on the Raspberry Pi.
 
 ```bash
 $ sudo dpkg --add-architecture armhf


### PR DESCRIPTION
missing instruction added for Ubuntu install users.
https://github.com/ROBOTIS-GIT/OpenCR-Binaries/issues/4