### PR TITLE
Update spelling mistake & broken link in opencr10.md

### DIFF
--- a/docs/en/parts/controller/opencr10.md
+++ b/docs/en/parts/controller/opencr10.md
@@ -1163,7 +1163,7 @@ void loop()
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/7fOIeFTg7bY" frameborder="0" gesture="media" allow="encrypted-media" allowfullscreen></iframe>
 
-## [DYNMAIXEL Workbench](#dynamixel-workbench)
+## [DYNAMIXEL Workbench](#dynamixel-workbench)
 
 - [DYNAMIXEL Workbench examples](/docs/en/software/dynamixel/dynamixel_workbench/#opencr-and-opencm-tutorials)
 


### PR DESCRIPTION
Corrected spelling mistake in heading so the hashlink works correctly.