### PR TITLE
Fixed typo of motor type.

### DIFF
--- a/docs/en/dxl/pro/m42-10-s260-ra.md
+++ b/docs/en/dxl/pro/m42-10-s260-ra.md
@@ -21,7 +21,7 @@ product_group: dxl_pro_a
 | Item                   | Specifications                                                                                                                                                  |
 |:-----------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | MCU                    | ARM CORTEX-M4 (168 [MHz], 32Bit)                                                                                                                                |
-| Motor                  | BLDC(Maxon)                                                                                                                                                     |
+| Motor                  | Coreless(Maxon)                                                                                                                                                     |
 | Baud Rate              | 9,600 [bps] ~ 10.5 [Mbps]                                                                                                                                       |
 | Operating Modes        | Torque Control Mode<br />Velocity Control Mode<br />Position Control Mode<br />Extended Position Control Mode<br />PWM Control Mode(Voltage Control Mode)<br /> |
 | Weight                 | 269 [g]                                                                                                                                                         |


### PR DESCRIPTION
The model is the same, but the description of the motor is different.
Therefore, the description of the motor of M42-10-S260-R(A) has been corrected to the same as that of M42-10-S260-R.