### PR TITLE
Fix misspelling of 'Secondary'

### DIFF
--- a/docs/en/dxl/p/ph42-020-s300-r.md
+++ b/docs/en/dxl/p/ph42-020-s300-r.md
@@ -46,7 +46,7 @@ product_group: dxl_p
 |    9    |     1      |         N/A         | [Return Delay Time](#return-delay-time)     |   RW   |        250         |                             0 ~ 254                              |        2 [μsec]         |
 |   10    |     1      |  _40006 (Lo Byte)_  | [Drive Mode](#drive-mode)                   |   RW   |         0          |                              0 ~ 1                               |            -            |
 |   11    |     1      |  _40006 (Hi Byte)_  | [Operating Mode](#operating-mode)           |   RW   |         3          |                          0, 1, 3, 4, 16                          |            -            |
-|   12    |     1      |         N/A         | [Sencondary(Shadow) ID](#secondary-id)      |   RW   |        255         |                             0 ~ 255                              |            -            |
+|   12    |     1      |         N/A         | [Secondary(Shadow) ID](#secondary-id)      |   RW   |        255         |                             0 ~ 255                              |            -            |
 |   13    |     1      |  _40007 (Hi Byte)_  | [Protocol Type](#protocol-type13)           |   RW   |         2          |                              2, 10                               |            -            |
 |   20    |     4      |       _40011_       | [Homing Offset](#homing-offset)             |   RW   |         0          |                -2,147,483,648 ~<br> 2,147,483,647                |        1 [pulse]        |
 |   24    |     4      |       _40013_       | [Moving Threshold](#moving-threshold)       |   RW   |         20         |                            0 ~ 2,920                             |     0.01 [rev/min]      |

--- a/docs/en/dxl/p/ph54-100-s500-r.md
+++ b/docs/en/dxl/p/ph54-100-s500-r.md
@@ -47,7 +47,7 @@ product_group: dxl_p
 |   10    |     1      |  _40006 (Lo Byte)_  | [Drive Mode](#drive-mode)                   |   RW   |         0          |                              0 ~ 1                               |            -            |
 |   11    |     1      |  _40006 (Hi Byte)_  | [Operating Mode](#operating-mode)           |   RW   |         3          |                          0, 1, 3, 4, 16                          |            -            |
 |   13    |     1      |  _40007 (Lo Byte)_  | [Protocol Type](#protocol-type13)           |   RW   |         2          |                              2, 10                               |            -            |
-|   12    |     1      |         N/A         | [Sencondary(Shadow) ID](#secondary-id)      |   RW   |        255         |                             0 ~ 255                              |            -            |
+|   12    |     1      |         N/A         | [Secondary(Shadow) ID](#secondary-id)      |   RW   |        255         |                             0 ~ 255                              |            -            |
 |   20    |     4      |       _40011_       | [Homing Offset](#homing-offset)             |   RW   |         0          |                -2,147,483,648 ~<br> 2,147,483,647                |        1 [pulse]        |
 |   24    |     4      |       _40013_       | [Moving Threshold](#moving-threshold)       |   RW   |         20         |                            0 ~ 2,920                             |     0.01 [rev/min]      |
 |   31    |     1      |  _40016 (Hi Byte)_  | [Temperature Limit](#temperature-limit)     |   RW   |         80         |                             0 ~ 100                              |       1 [&deg;C]        |

--- a/docs/en/dxl/p/ph54-200-s500-r.md
+++ b/docs/en/dxl/p/ph54-200-s500-r.md
@@ -46,7 +46,7 @@ product_group: dxl_p
 |    9    |     1      |         N/A         |   [Return Delay Time](#return-delay-time)   |   RW   |        250         |                             0 ~ 254                              |        2 [μsec]         |
 |   10    |     1      |  _40006 (Lo Byte)_  |          [Drive Mode](#drive-mode)          |   RW   |         0          |                              0 ~ 1                               |            -            |
 |   11    |     1      |  _40006 (Hi Byte)_  |      [Operating Mode](#operating-mode)      |   RW   |         3          |                          0, 1, 3, 4, 16                          |            -            |
-|   12    |     1      |         N/A         |   [Sencondary(Shadow) ID](#secondary-id)    |   RW   |        255         |                             0 ~ 255                              |            -            |
+|   12    |     1      |         N/A         |   [Secondary(Shadow) ID](#secondary-id)    |   RW   |        255         |                             0 ~ 255                              |            -            |
 |   13    |     1      |  _40007 (Hi Byte)_  |      [Protocol Type](#protocol-type13)      |   RW   |         2          |                              2, 10                               |            -            |
 |   20    |     4      |       _40011_       |       [Homing Offset](#homing-offset)       |   RW   |         0          |                -2,147,483,648 ~<br> 2,147,483,647                |        1 [pulse]        |
 |   24    |     4      |       _40013_       |    [Moving Threshold](#moving-threshold)    |   RW   |         20         |                            0 ~ 2,900                             |     0.01 [rev/min]      |

--- a/docs/en/dxl/p/pm42-010-s260-r.md
+++ b/docs/en/dxl/p/pm42-010-s260-r.md
@@ -46,7 +46,7 @@ product_group: dxl_p
 |    9    |     1      |         N/A         | [Return Delay Time](#return-delay-time)     |   RW   |        250         |                             0 ~ 254                              |        2 [μsec]         |
 |   10    |     1      |  *40006 (Lo Byte)*  | [Drive Mode](#drive-mode)                   |   RW   |         0          |                              0 ~ 1                               |            -            |
 |   11    |     1      |  *40006 (Hi Byte)*  | [Operating Mode](#operating-mode)           |   RW   |         3          |                          0, 1, 3, 4, 16                          |            -            |
-|   12    |     1      |         N/A         | [Sencondary ID](#secondary-id)              |   RW   |        255         |                             0 ~ 255                              |            -            |
+|   12    |     1      |         N/A         | [Secondary ID](#secondary-id)              |   RW   |        255         |                             0 ~ 255                              |            -            |
 |   13    |     1      |  *40007 (Hi Byte)*  | [Protocol Type](#protocol-type13)           |   RW   |         2          |                              2, 10                               |            -            |
 |   20    |     4      |       *40011*       | [Homing Offset](#homing-offset)             |   RW   |         0          |                -2,147,483,648 ~<br> 2,147,483,647                |        1 [pulse]        |
 |   24    |     4      |       *40013*       | [Moving Threshold](#moving-threshold)       |   RW   |         20         |                            0 ~ 2,600                             |     0.01 [rev/min]      |

--- a/docs/en/dxl/p/pm54-040-s250-r.md
+++ b/docs/en/dxl/p/pm54-040-s250-r.md
@@ -46,7 +46,7 @@ product_group: dxl_p
 |    9    |     1      |         N/A         | [Return Delay Time](#return-delay-time)     |   RW   |        250         |                             0 ~ 254                              |        2 [μsec]         |
 |   10    |     1      |  *40006 (Lo Byte)*  | [Drive Mode](#drive-mode)                   |   RW   |         0          |                              0 ~ 1                               |            -            |
 |   11    |     1      |  *40006 (Hi Byte)*  | [Operating Mode](#operating-mode)           |   RW   |         3          |                          0, 1, 3, 4, 16                          |            -            |
-|   12    |     1      |         N/A         | [Sencondary ID](#secondary-id)              |   RW   |        255         |                             0 ~ 255                              |            -            |
+|   12    |     1      |         N/A         | [Secondary ID](#secondary-id)              |   RW   |        255         |                             0 ~ 255                              |            -            |
 |   13    |     1      |  *40007 (Hi Byte)*  | [Protocol Type](#protocol-type13)           |   RW   |         2          |                              2, 10                               |            -            |
 |   20    |     4      |       *40011*       | [Homing Offset](#homing-offset)             |   RW   |         0          |                -2,147,483,648 ~<br> 2,147,483,647                |        1 [pulse]        |
 |   24    |     4      |       *40013*       | [Moving Threshold](#moving-threshold)       |   RW   |         20         |                            0 ~ 2,840                             |     0.01 [rev/min]      |

--- a/docs/en/dxl/pro/h42-20-s300-ra.md
+++ b/docs/en/dxl/pro/h42-20-s300-ra.md
@@ -46,7 +46,7 @@ product_group: dxl_pro_a
 |    9    |       1        | [Return Delay Time](#return-delay-time)     |   RW   |        250         |              0 ~ 255               |        2 [μsec]         |
 |   10    |       1        | [Drive Mode](#drive-mode)                   |   RW   |         0          |               0 ~ 1                |            -            |
 |   11    |       1        | [Operating Mode](#operating-mode)           |   RW   |         3          |           0, 1, 3, 4, 16           |            -            |
-|   12    |       1        | [Sencondary ID](#secondary-id)              |   RW   |        255         |              0 ~ 255               |            -            |
+|   12    |       1        | [Secondary ID](#secondary-id)              |   RW   |        255         |              0 ~ 255               |            -            |
 |   20    |       4        | [Homing Offset](#homing-offset)             |   RW   |         0          | -2,147,483,648 ~<br> 2,147,483,647 |        1 [pulse]        |
 |   24    |       4        | [Moving Threshold](#moving-threshold)       |   RW   |         20         |             0 ~ 2,920              |     0.01 [rev/min]      |
 |   31    |       1        | [Temperature Limit](#temperature-limit)     |   RW   |         80         |              0 ~ 100               |       1 [&deg;C]        |

--- a/docs/en/dxl/pro/h54-100-s500-ra.md
+++ b/docs/en/dxl/pro/h54-100-s500-ra.md
@@ -46,7 +46,7 @@ product_group: dxl_pro_a
 |    9    |       1        | [Return Delay Time](#return-delay-time)     |   RW   |        250         |              0 ~ 255               |        2 [μsec]         |
 |   10    |       1        | [Drive Mode](#drive-mode)                   |   RW   |         0          |               0 ~ 1                |            -            |
 |   11    |       1        | [Operating Mode](#operating-mode)           |   RW   |         3          |           0, 1, 3, 4, 16           |            -            |
-|   12    |       1        | [Sencondary ID](#secondary-id)              |   RW   |        255         |              0 ~ 255               |            -            |
+|   12    |       1        | [Secondary ID](#secondary-id)              |   RW   |        255         |              0 ~ 255               |            -            |
 |   20    |       4        | [Homing Offset](#homing-offset)             |   RW   |         0          | -2,147,483,648 ~<br> 2,147,483,647 |        1 [pulse]        |
 |   24    |       4        | [Moving Threshold](#moving-threshold)       |   RW   |         50         |             0 ~ 2,920              |     0.01 [rev/min]      |
 |   31    |       1        | [Temperature Limit](#temperature-limit)     |   RW   |         80         |              0 ~ 100               |       1 [&deg;C]        |

--- a/docs/en/dxl/pro/h54-200-s500-ra.md
+++ b/docs/en/dxl/pro/h54-200-s500-ra.md
@@ -46,7 +46,7 @@ product_group: dxl_pro_a
 |    9    |       1        | [Return Delay Time](#return-delay-time)     | RW     |        250         |              0 ~ 255               |        2 [μsec]         |
 |   10    |       1        | [Drive Mode](#drive-mode)                   | RW     |         0          |               0 ~ 1                |            -            |
 |   11    |       1        | [Operating Mode](#operating-mode)           | RW     |         3          |           0, 1, 3, 4, 16           |            -            |
-|   12    |       1        | [Sencondary ID](#secondary-id)              | RW     |        255         |              0 ~ 255               |            -            |
+|   12    |       1        | [Secondary ID](#secondary-id)              | RW     |        255         |              0 ~ 255               |            -            |
 |   20    |       4        | [Homing Offset](#homing-offset)             | RW     |         0          | -2,147,483,648 ~<br> 2,147,483,647 |        1 [pulse]        |
 |   24    |       4        | [Moving Threshold](#moving-threshold)       | RW     |         20         |             0 ~ 2,900              |     0.01 [rev/min]      |
 |   31    |       1        | [Temperature Limit](#temperature-limit)     | RW     |         80         |              0 ~ 100               |       1 [&deg;C]        |

--- a/docs/en/dxl/pro/m42-10-s260-ra.md
+++ b/docs/en/dxl/pro/m42-10-s260-ra.md
@@ -46,7 +46,7 @@ product_group: dxl_pro_a
 |    9    |       1        | [Return Delay Time](#return-delay-time)     |   RW   |        250         |              0 ~ 255               |        2 [μsec]         |
 |   10    |       1        | [Drive Mode](#drive-mode)                   |   RW   |         0          |               0 ~ 1                |            -            |
 |   11    |       1        | [Operating Mode](#operating-mode)           |   RW   |         3          |           0, 1, 3, 4, 16           |            -            |
-|   12    |       1        | [Sencondary ID](#secondary-id)              |   RW   |        255         |              0 ~ 255               |            -            |
+|   12    |       1        | [Secondary ID](#secondary-id)              |   RW   |        255         |              0 ~ 255               |            -            |
 |   20    |       4        | [Homing Offset](#homing-offset)             |   RW   |         0          | -2,147,483,648 ~<br> 2,147,483,647 |        1 [pulse]        |
 |   24    |       4        | [Moving Threshold](#moving-threshold)       |   RW   |         20         |             0 ~ 2,600              |     0.01 [rev/min]      |
 |   31    |       1        | [Temperature Limit](#temperature-limit)     |   RW   |         80         |              0 ~ 100               |       1 [&deg;C]        |

--- a/docs/en/dxl/pro/m54-40-s250-ra.md
+++ b/docs/en/dxl/pro/m54-40-s250-ra.md
@@ -68,7 +68,7 @@ product_group: dxl_pro_a
 |    9    |       1        | [Return Delay Time](#return-delay-time)     |   RW   |        250         |              0 ~ 255               |        2 [μsec]         |
 |   10    |       1        | [Drive Mode](#drive-mode)                   |   RW   |         0          |               0 ~ 1                |            -            |
 |   11    |       1        | [Operating Mode](#operating-mode)           |   RW   |         3          |           0, 1, 3, 4, 16           |            -            |
-|   12    |       1        | [Sencondary ID](#secondary-id)              |   RW   |        255         |              0 ~ 255               |            -            |
+|   12    |       1        | [Secondary ID](#secondary-id)              |   RW   |        255         |              0 ~ 255               |            -            |
 |   20    |       4        | [Homing Offset](#homing-offset)             |   RW   |         0          | -2,147,483,648 ~<br> 2,147,483,647 |        1 [pulse]        |
 |   24    |       4        | [Moving Threshold](#moving-threshold)       |   RW   |         20         |             0 ~ 2,840              |     0.01 [rev/min]      |
 |   31    |       1        | [Temperature Limit](#temperature-limit)     |   RW   |         80         |              0 ~ 100               |       1 [&deg;C]        |

--- a/docs/en/dxl/pro/m54-60-s250-ra.md
+++ b/docs/en/dxl/pro/m54-60-s250-ra.md
@@ -68,7 +68,7 @@ product_group: dxl_pro_a
 |    9    |       1        | [Return Delay Time](#return-delay-time)     |   RW   |        250         |              0 ~ 255               |        2 [μsec]         |
 |   10    |       1        | [Drive Mode](#drive-mode)                   |   RW   |         0          |               0 ~ 1                |            -            |
 |   11    |       1        | [Operating Mode](#operating-mode)           |   RW   |         3          |           0, 1, 3, 4, 16           |            -            |
-|   12    |       1        | [Sencondary ID](#secondary-id)              |   RW   |        255         |              0 ~ 255               |            -            |
+|   12    |       1        | [Secondary ID](#secondary-id)              |   RW   |        255         |              0 ~ 255               |            -            |
 |   20    |       4        | [Homing Offset](#homing-offset)             |   RW   |         0          | -2,147,483,648 ~<br> 2,147,483,647 |        1 [pulse]        |
 |   24    |       4        | [Moving Threshold](#moving-threshold)       |   RW   |         50         |             0 ~ 2,830              |     0.01 [rev/min]      |
 |   31    |       1        | [Temperature Limit](#temperature-limit)     |   RW   |         80         |              0 ~ 100               |       1 [&deg;C]        |

--- a/docs/en/platform/rh_p12_rn/rh-p12-rna.md
+++ b/docs/en/platform/rh_p12_rn/rh-p12-rna.md
@@ -85,7 +85,7 @@ You can choose the desired firmware version by using **Firmware Recovery** of [R
 |    8    |       1        |  *40005 (Lo Byte)*  | [Baud Rate](#baud-rate)                     |   RW   |         1          |     0 ~ 9     |            -            |
 |    9    |       1        |         N/A         | [Return Delay Time](#return-delay-time)     |   RW   |        250         |    0 ~ 255    |        2 [μsec]         |
 |   11    |       1        |  *40006 (Hi Byte)*  | [Operating Mode](#operating-mode)           |   RW   |         5          |     0, 5      |            -            |
-|   12    |       1        |         N/A         | [Sencondary ID](#secondary-id)              |   RW   |        255         |    0 ~ 255    |            -            |
+|   12    |       1        |         N/A         | [Secondary ID](#secondary-id)              |   RW   |        255         |    0 ~ 255    |            -            |
 |   13    |       1        |  *40007 (Hi Byte)*  | [Protocol Type](#protocol-type13)           |   RW   |         2          |     2, 10     |            -            |
 |   20    |       4        |       *40011*       | [Homing Offset](#homing-offset)             |   RW   |         0          |   0 ~ 1,150   |        1 [pulse]        |
 |   24    |       4        |       *40013*       | [Moving Threshold](#moving-threshold)       |   RW   |         80         |   0 ~ 2,970   |     0.01 [rev/min]      |

--- a/docs/kr/dxl/p/ph42-020-s300-r.md
+++ b/docs/kr/dxl/p/ph42-020-s300-r.md
@@ -46,7 +46,7 @@ product_group: dxl_p
 |  9   |     1      |        N/A        |   [Return Delay Time](#return-delay-time)   |  RW  |   250    |                             0 ~ 254                              | 2 [μsec]                |
 |  10  |     1      | *40006 (Lo Byte)* |          [Drive Mode](#drive-mode)          |  RW  |    0     |                              0 ~ 1                               | -                       |
 |  11  |     1      | *40006 (Hi Byte)* |      [Operating Mode](#operating-mode)      |  RW  |    3     |                          0, 1, 3, 4, 16                          | -                       |
-|  12  |     1      |        N/A        |   [Sencondary(Shadow) ID](#secondary-id)    |  RW  |   255    |                             0 ~ 255                              | -                       |
+|  12  |     1      |        N/A        |   [Secondary(Shadow) ID](#secondary-id)    |  RW  |   255    |                             0 ~ 255                              | -                       |
 |  13  |     1      | *40007 (Hi Byte)* |      [Protocol Type](#protocol-type13)      |  RW  |    2     |                              2, 10                               | -                       |
 |  20  |     4      |      *40011*      |       [Homing Offset](#homing-offset)       |  RW  |    0     |                -2,147,483,648 ~<br> 2,147,483,647                | 1 [pulse]               |
 |  24  |     4      |      *40013*      |    [Moving Threshold](#moving-threshold)    |  RW  |    20    |                            0 ~ 2,920                             | 0.01 [rev/min]          |

--- a/docs/kr/dxl/p/ph54-100-s500-r.md
+++ b/docs/kr/dxl/p/ph54-100-s500-r.md
@@ -46,7 +46,7 @@ product_group: dxl_p
 |  9   |     1      |        N/A        | [Return Delay Time](#return-delay-time)     |  RW  |   250    |                             0 ~ 254                              |        2 [μsec]         |
 |  10  |     1      | _40006 (Lo Byte)_ | [Drive Mode](#drive-mode)                   |  RW  |    0     |                              0 ~ 1                               |            -            |
 |  11  |     1      | _40006 (Hi Byte)_ | [Operating Mode](#operating-mode)           |  RW  |    3     |                          0, 1, 3, 4, 16                          |            -            |
-|  12  |     1      |        N/A        | [Sencondary(Shadow) ID](#secondary-id)      |  RW  |   255    |                             0 ~ 255                              |            -            |
+|  12  |     1      |        N/A        | [Secondary(Shadow) ID](#secondary-id)      |  RW  |   255    |                             0 ~ 255                              |            -            |
 |  13  |     1      | _40007 (Hi Byte)_ | [Protocol Type](#protocol-type13)           |  RW  |    2     |                              2, 10                               |            -            |
 |  20  |     4      |      _40011_      | [Homing Offset](#homing-offset)             |  RW  |    0     |                -2,147,483,648 ~<br> 2,147,483,647                |        1 [pulse]        |
 |  24  |     4      |      _40013_      | [Moving Threshold](#moving-threshold)       |  RW  |    20    |                            0 ~ 2,920                             |     0.01 [rev/min]      |

--- a/docs/kr/dxl/p/ph54-200-s500-r.md
+++ b/docs/kr/dxl/p/ph54-200-s500-r.md
@@ -46,7 +46,7 @@ product_group: dxl_p
 |  9   |     1      |        N/A        |   [Return Delay Time](#return-delay-time)   |  RW  |   250    |                             0 ~ 254                              |        2 [μsec]         |
 |  10  |     1      | _40006 (Lo Byte)_ |          [Drive Mode](#drive-mode)          |  RW  |    0     |                              0 ~ 1                               |            -            |
 |  11  |     1      | _40006 (Hi Byte)_ |      [Operating Mode](#operating-mode)      |  RW  |    3     |                          0, 1, 3, 4, 16                          |            -            |
-|  12  |     1      |        N/A        |   [Sencondary(Shadow) ID](#secondary-id)    |  RW  |   255    |                             0 ~ 255                              |            -            |
+|  12  |     1      |        N/A        |   [Secondary(Shadow) ID](#secondary-id)    |  RW  |   255    |                             0 ~ 255                              |            -            |
 |  13  |     1      | _40007 (Hi Byte)_ |      [Protocol Type](#protocol-type13)      |  RW  |    2     |                              2, 10                               |            -            |
 |  20  |     4      |      _40011_      |       [Homing Offset](#homing-offset)       |  RW  |    0     |                -2,147,483,648 ~<br> 2,147,483,647                |        1 [pulse]        |
 |  24  |     4      |      _40013_      |    [Moving Threshold](#moving-threshold)    |  RW  |    20    |                            0 ~ 2,900                             |     0.01 [rev/min]      |

--- a/docs/kr/dxl/p/pm42-010-s260-r.md
+++ b/docs/kr/dxl/p/pm42-010-s260-r.md
@@ -46,7 +46,7 @@ product_group: dxl_p
 |  9   |     1      |        N/A        | [Return Delay Time](#return-delay-time)     |  RW  |   250    |                             0 ~ 254                              |        2 [μsec]         |
 |  10  |     1      | *40006 (Lo Byte)* | [Drive Mode](#drive-mode)                   |  RW  |    0     |                              0 ~ 1                               |            -            |
 |  11  |     1      | *40006 (Hi Byte)* | [Operating Mode](#operating-mode)           |  RW  |    3     |                          0, 1, 3, 4, 16                          |            -            |
-|  12  |     1      |        N/A        | [Sencondary ID](#secondary-id)              |  RW  |   255    |                             0 ~ 255                              |            -            |
+|  12  |     1      |        N/A        | [Secondary ID](#secondary-id)              |  RW  |   255    |                             0 ~ 255                              |            -            |
 |  13  |     1      | *40007 (Hi Byte)* | [Protocol Type](#protocol-type13)           |  RW  |    2     |                              2, 10                               |            -            |
 |  20  |     4      |      *40011*      | [Homing Offset](#homing-offset)             |  RW  |    0     |                -2,147,483,648 ~<br> 2,147,483,647                |        1 [pulse]        |
 |  24  |     4      |      *40013*      | [Moving Threshold](#moving-threshold)       |  RW  |    20    |                            0 ~ 2,600                             |     0.01 [rev/min]      |

--- a/docs/kr/dxl/p/pm54-040-s250-r.md
+++ b/docs/kr/dxl/p/pm54-040-s250-r.md
@@ -46,7 +46,7 @@ product_group: dxl_p
 |  9   |     1      |        N/A        | [Return Delay Time](#return-delay-time)     |  RW  |   250    |                             0 ~ 254                              |        2 [μsec]         |
 |  10  |     1      | *40006 (Lo Byte)* | [Drive Mode](#drive-mode)                   |  RW  |    0     |                              0 ~ 1                               |            -            |
 |  11  |     1      | *40006 (Hi Byte)* | [Operating Mode](#operating-mode)           |  RW  |    3     |                          0, 1, 3, 4, 16                          |            -            |
-|  12  |     1      |        N/A        | [Sencondary ID](#secondary-id)              |  RW  |   255    |                             0 ~ 255                              |            -            |
+|  12  |     1      |        N/A        | [Secondary ID](#secondary-id)              |  RW  |   255    |                             0 ~ 255                              |            -            |
 |  13  |     1      | *40007 (Hi Byte)* | [Protocol Type](#protocol-type13)           |  RW  |    2     |                              2, 10                               |            -            |
 |  20  |     4      |      *40011*      | [Homing Offset](#homing-offset)             |  RW  |    0     |                -2,147,483,648 ~<br> 2,147,483,647                |        1 [pulse]        |
 |  24  |     4      |      *40013*      | [Moving Threshold](#moving-threshold)       |  RW  |    20    |                            0 ~ 2,840                             |     0.01 [rev/min]      |

--- a/docs/kr/dxl/p/pm54-060-s250-r.md
+++ b/docs/kr/dxl/p/pm54-060-s250-r.md
@@ -46,7 +46,7 @@ product_group: dxl_p
 |  9   |     1      |        N/A        | [Return Delay Time](#return-delay-time)     |  RW  |   250    |                             0 ~ 254                              |        2 [μsec]         |
 |  10  |     1      | *40006 (Lo Byte)* | [Drive Mode](#drive-mode)                   |  RW  |    0     |                              0 ~ 1                               |            -            |
 |  11  |     1      | *40006 (Hi Byte)* | [Operating Mode](#operating-mode)           |  RW  |    3     |                          0, 1, 3, 4, 16                          |            -            |
-|  12  |     1      |        N/A        | [Sencondary ID](#secondary-id)              |  RW  |   255    |                             0 ~ 255                              |            -            |
+|  12  |     1      |        N/A        | [Secondary ID](#secondary-id)              |  RW  |   255    |                             0 ~ 255                              |            -            |
 |  13  |     1      | *40007 (Hi Byte)* | [Protocol Type](#protocol-type13)           |  RW  |    2     |                              2, 10                               |            -            |
 |  20  |     4      |      *40011*      | [Homing Offset](#homing-offset)             |  RW  |    0     |                -2,147,483,648 ~<br> 2,147,483,647                |        1 [pulse]        |
 |  24  |     4      |      *40013*      | [Moving Threshold](#moving-threshold)       |  RW  |    20    |                            0 ~ 2,830                             |     0.01 [rev/min]      |

--- a/docs/kr/dxl/pro/h42-20-s300-ra.md
+++ b/docs/kr/dxl/pro/h42-20-s300-ra.md
@@ -46,7 +46,7 @@ product_group: dxl_pro_a
 |  9   |       1        | [Return Delay Time](#return-delay-time)     |  RW  |   250    |              0 ~ 255               |        2 [μsec]         |
 |  10  |       1        | [Drive Mode](#drive-mode)                   |  RW  |    0     |               0 ~ 1                |            -            |
 |  11  |       1        | [Operating Mode](#operating-mode)           |  RW  |    3     |           0, 1, 3, 4, 16           |            -            |
-|  12  |       1        | [Sencondary ID](#secondary-id)              |  RW  |   255    |              0 ~ 255               |            -            |
+|  12  |       1        | [Secondary ID](#secondary-id)              |  RW  |   255    |              0 ~ 255               |            -            |
 |  20  |       4        | [Homing Offset](#homing-offset)             |  RW  |    0     | -2,147,483,648 ~<br> 2,147,483,647 |        1 [pulse]        |
 |  24  |       4        | [Moving Threshold](#moving-threshold)       |  RW  |    20    |             0 ~ 2,920              |     0.01 [rev/min]      |
 |  31  |       1        | [Temperature Limit](#temperature-limit)     |  RW  |    80    |              0 ~ 100               |       1 [&deg;C]        |

--- a/docs/kr/dxl/pro/h54-100-s500-ra.md
+++ b/docs/kr/dxl/pro/h54-100-s500-ra.md
@@ -46,7 +46,7 @@ product_group: dxl_pro_a
 |  9   |       1        | [Return Delay Time](#return-delay-time)     |  RW  |   250    |              0 ~ 255               |        2 [μsec]         |
 |  10  |       1        | [Drive Mode](#drive-mode)                   |  RW  |    0     |               0 ~ 1                |            -            |
 |  11  |       1        | [Operating Mode](#operating-mode)           |  RW  |    3     |           0, 1, 3, 4, 16           |            -            |
-|  12  |       1        | [Sencondary ID](#secondary-id)              |  RW  |   255    |              0 ~ 255               |            -            |
+|  12  |       1        | [Secondary ID](#secondary-id)              |  RW  |   255    |              0 ~ 255               |            -            |
 |  20  |       4        | [Homing Offset](#homing-offset)             |  RW  |    0     | -2,147,483,648 ~<br> 2,147,483,647 |        1 [pulse]        |
 |  24  |       4        | [Moving Threshold](#moving-threshold)       |  RW  |    50    |             0 ~ 2,920              |     0.01 [rev/min]      |
 |  31  |       1        | [Temperature Limit](#temperature-limit)     |  RW  |    80    |              0 ~ 100               |       1 [&deg;C]        |

--- a/docs/kr/dxl/pro/h54-200-s500-ra.md
+++ b/docs/kr/dxl/pro/h54-200-s500-ra.md
@@ -46,7 +46,7 @@ product_group: dxl_pro_a
 |  9   |       1        | [Return Delay Time](#return-delay-time)     |  RW  |   250    |              0 ~ 255               |        2 [μsec]         |
 |  10  |       1        | [Drive Mode](#drive-mode)                   |  RW  |    0     |               0 ~ 1                |            -            |
 |  11  |       1        | [Operating Mode](#operating-mode)           |  RW  |    3     |           0, 1, 3, 4, 16           |            -            |
-|  12  |       1        | [Sencondary ID](#secondary-id)              |  RW  |   255    |              0 ~ 255               |            -            |
+|  12  |       1        | [Secondary ID](#secondary-id)              |  RW  |   255    |              0 ~ 255               |            -            |
 |  20  |       4        | [Homing Offset](#homing-offset)             |  RW  |    0     | -2,147,483,648 ~<br> 2,147,483,647 |        1 [pulse]        |
 |  24  |       4        | [Moving Threshold](#moving-threshold)       |  RW  |    20    |             0 ~ 2,900              |     0.01 [rev/min]      |
 |  31  |       1        | [Temperature Limit](#temperature-limit)     |  RW  |    80    |              0 ~ 100               |       1 [&deg;C]        |

--- a/docs/kr/dxl/pro/m42-10-s260-ra.md
+++ b/docs/kr/dxl/pro/m42-10-s260-ra.md
@@ -41,7 +41,7 @@ product_group: dxl_pro_a
 |  9   |       1        | [Return Delay Time](#return-delay-time)     |  RW  |   250    |              0 ~ 255               |        2 [μsec]         |
 |  10  |       1        | [Drive Mode](#drive-mode)                   |  RW  |    0     |               0 ~ 1                |            -            |
 |  11  |       1        | [Operating Mode](#operating-mode)           |  RW  |    3     |           0, 1, 3, 4, 16           |            -            |
-|  12  |       1        | [Sencondary ID](#secondary-id)              |  RW  |   255    |              0 ~ 255               |            -            |
+|  12  |       1        | [Secondary ID](#secondary-id)              |  RW  |   255    |              0 ~ 255               |            -            |
 |  20  |       4        | [Homing Offset](#homing-offset)             |  RW  |    0     | -2,147,483,648 ~<br> 2,147,483,647 |        1 [pulse]        |
 |  24  |       4        | [Moving Threshold](#moving-threshold)       |  RW  |    20    |             0 ~ 2,600              |     0.01 [rev/min]      |
 |  31  |       1        | [Temperature Limit](#temperature-limit)     |  RW  |    80    |              0 ~ 100               |       1 [&deg;C]        |

--- a/docs/kr/dxl/pro/m54-40-s250-ra.md
+++ b/docs/kr/dxl/pro/m54-40-s250-ra.md
@@ -41,7 +41,7 @@ product_group: dxl_pro_a
 |  9   |       1        | [Return Delay Time](#return-delay-time)     |  RW  |   250    |              0 ~ 255               |        2 [μsec]         |
 |  10  |       1        | [Drive Mode](#drive-mode)                   |  RW  |    0     |               0 ~ 1                |            -            |
 |  11  |       1        | [Operating Mode](#operating-mode)           |  RW  |    3     |           0, 1, 3, 4, 16           |            -            |
-|  12  |       1        | [Sencondary ID](#secondary-id)              |  RW  |   255    |              0 ~ 255               |            -            |
+|  12  |       1        | [Secondary ID](#secondary-id)              |  RW  |   255    |              0 ~ 255               |            -            |
 |  20  |       4        | [Homing Offset](#homing-offset)             |  RW  |    0     | -2,147,483,648 ~<br> 2,147,483,647 |        1 [pulse]        |
 |  24  |       4        | [Moving Threshold](#moving-threshold)       |  RW  |    20    |             0 ~ 2,840              |     0.01 [rev/min]      |
 |  31  |       1        | [Temperature Limit](#temperature-limit)     |  RW  |    80    |              0 ~ 100               |       1 [&deg;C]        |

--- a/docs/kr/dxl/pro/m54-60-s250-ra.md
+++ b/docs/kr/dxl/pro/m54-60-s250-ra.md
@@ -41,7 +41,7 @@ product_group: dxl_pro_a
 |  9   |       1        | [Return Delay Time](#return-delay-time)     |  RW  |   250    |              0 ~ 255               |        2 [μsec]         |
 |  10  |       1        | [Drive Mode](#drive-mode)                   |  RW  |    0     |               0 ~ 1                |            -            |
 |  11  |       1        | [Operating Mode](#operating-mode)           |  RW  |    3     |           0, 1, 3, 4, 16           |            -            |
-|  12  |       1        | [Sencondary ID](#secondary-id)              |  RW  |   255    |              0 ~ 255               |            -            |
+|  12  |       1        | [Secondary ID](#secondary-id)              |  RW  |   255    |              0 ~ 255               |            -            |
 |  20  |       4        | [Homing Offset](#homing-offset)             |  RW  |    0     | -2,147,483,648 ~<br> 2,147,483,647 |        1 [pulse]        |
 |  24  |       4        | [Moving Threshold](#moving-threshold)       |  RW  |    50    |             0 ~ 2,830              |     0.01 [rev/min]      |
 |  31  |       1        | [Temperature Limit](#temperature-limit)     |  RW  |    80    |              0 ~ 100               |       1 [&deg;C]        |

--- a/docs/kr/platform/rh_p12_rn/rh-p12-rna.md
+++ b/docs/kr/platform/rh_p12_rn/rh-p12-rna.md
@@ -87,7 +87,7 @@ page_number: 1
 |  8   |       1        |  *40005 (Lo Byte)*  | [Baud Rate](#baud-rate)                     |  RW  |   1    |     0 ~ 9     |            -            |
 |  9   |       1        |         N/A         | [Return Delay Time](#return-delay-time)     |  RW  |  250   |    0 ~ 255    |        2 [μsec]         |
 |  11  |       1        |  *40006 (Hi Byte)*  | [Operating Mode](#operating-mode)           |  RW  |   5    |     0, 5      |            -            |
-|  12  |       1        |         N/A         | [Sencondary ID](#secondary-id)              |  RW  |  255   |    0 ~ 255    |            -            |
+|  12  |       1        |         N/A         | [Secondary ID](#secondary-id)              |  RW  |  255   |    0 ~ 255    |            -            |
 |  13  |       1        |  *40007 (Hi Byte)*  | [Protocol Type](#protocol-type13)           |  RW  |   2    |     2, 10     |            -            |
 |  20  |       4        |       *40011*       | [Homing Offset](#homing-offset)             |  RW  |   0    |   0 ~ 1,150   |        1 [pulse]        |
 |  24  |       4        |       *40013*       | [Moving Threshold](#moving-threshold)       |  RW  |   80   |   0 ~ 2,970   |     0.01 [rev/min]      |


### PR DESCRIPTION
I noticed some misspellings of the word 'Secondary' as 'Sencondary' in the documentation. This PR simply replaces the misspelled word with the correct spelling :slightly_smiling_face: 

Thank you for all your work in making the E-Manual such a helpful resource for Dynamixel information!