### PR TITLE
Fix: Wrong path

### DIFF
--- a/_includes/en/platform/turtlebot3/quickstart_windows.md
+++ b/_includes/en/platform/turtlebot3/quickstart_windows.md
@@ -29,7 +29,7 @@
   For more details, please refer to [Microsoft Instructions](https://ms-iot.github.io/ROSOnWindows/Turtlebot/Turtlebot3.html).
   ```
 > mkdir c:\ws\turtlebot3\src
-> cd c:\ws\turtlebot3\src
+> cd c:\ws\turtlebot3
 > curl -o tb3.repos https://raw.githubusercontent.com/ms-iot/ROSOnWindows/master/docs/Turtlebot/turtlebot3_ros1.repos
 > vcs import src < tb3.repos
   ```


### PR DESCRIPTION
``vcs import src <tb3.repos`` didn't work as Windows gave an error message since it couldn't find ``src`` while in the src folder