### PR TITLE
Fixed docs about where to connect RC100 on TB3.

### DIFF
--- a/_includes/en/platform/turtlebot3/basic_operation_dashing.md
+++ b/_includes/en/platform/turtlebot3/basic_operation_dashing.md
@@ -34,7 +34,7 @@ CTRL-C to quit
 
 #### [RC-100](#rc100)
 
-The settings for [ROBOTIS RC-100B][rc100] is included in an OpenCR firmware for TurtleBot3. It can be used with the Bluetooth module [BT410][bt410]. TurtleBot3 Waffle Pi includes this controller and Bluetooth modules. When using RC-100B, it is not necessary to execute a specific node because `turtlebot_core` node creates a `/cmd_vel` topic in the firmware directly connected to OpeCR.
+The settings for [ROBOTIS RC-100B][rc100] is included in an OpenCR firmware for TurtleBot3. It can be used with the Bluetooth module [BT410][bt410]. TurtleBot3 Waffle Pi includes this controller and Bluetooth modules. When using RC-100B, it is not necessary to execute a specific node because `turtlebot_core` node creates a `/cmd_vel` topic in the firmware directly connected to OpenCR.
 
 ![](/assets/images/platform/turtlebot3/example/rc100b_with_bt410.png)
 

--- a/_includes/en/platform/turtlebot3/basic_operation_dashing.md
+++ b/_includes/en/platform/turtlebot3/basic_operation_dashing.md
@@ -38,7 +38,7 @@ The settings for [ROBOTIS RC-100B][rc100] is included in an OpenCR firmware for 
 
 ![](/assets/images/platform/turtlebot3/example/rc100b_with_bt410.png)
 
-1. Connect BT-410 to any of OpenCR UART ports.
+1. Connect BT-410 to OpenCR UART1 port (as described [here][appendix_opencr1_0]).
 
 2. Control TurtleBot3 with RC-100.
   - Up / Down : Increase or decrease linear velocity

--- a/_includes/en/platform/turtlebot3/basic_operation_foxy.md
+++ b/_includes/en/platform/turtlebot3/basic_operation_foxy.md
@@ -34,7 +34,7 @@ CTRL-C to quit
 
 #### [RC-100](#rc100)
 
-The settings for [ROBOTIS RC-100B][rc100] is included in an OpenCR firmware for TurtleBot3. It can be used with the Bluetooth module [BT410][bt410]. TurtleBot3 Waffle Pi includes this controller and Bluetooth modules. When using RC-100B, it is not necessary to execute a specific node because `turtlebot_core` node creates a `/cmd_vel` topic in the firmware directly connected to OpeCR.
+The settings for [ROBOTIS RC-100B][rc100] is included in an OpenCR firmware for TurtleBot3. It can be used with the Bluetooth module [BT410][bt410]. TurtleBot3 Waffle Pi includes this controller and Bluetooth modules. When using RC-100B, it is not necessary to execute a specific node because `turtlebot_core` node creates a `/cmd_vel` topic in the firmware directly connected to OpenCR.
 
 ![](/assets/images/platform/turtlebot3/example/rc100b_with_bt410.png)
 

--- a/_includes/en/platform/turtlebot3/basic_operation_foxy.md
+++ b/_includes/en/platform/turtlebot3/basic_operation_foxy.md
@@ -38,7 +38,7 @@ The settings for [ROBOTIS RC-100B][rc100] is included in an OpenCR firmware for 
 
 ![](/assets/images/platform/turtlebot3/example/rc100b_with_bt410.png)
 
-1. Connect BT-410 to any of OpenCR UART ports.
+1. Connect BT-410 to OpenCR UART1 port (as described [here][appendix_opencr1_0]).
 
 2. Control TurtleBot3 with RC-100.
   - Up / Down : Increase or decrease linear velocity

--- a/_includes/en/platform/turtlebot3/basic_operation_kinetic.md
+++ b/_includes/en/platform/turtlebot3/basic_operation_kinetic.md
@@ -59,7 +59,7 @@ The settings for [ROBOTIS RC-100B][rc100] controller is included in the OpenCR f
 
 ![](/assets/images/platform/turtlebot3/example/rc100b_with_bt410.png)
 
-1. Connect BT-410 to any of OpenCR UART ports.
+1. Connect BT-410 to OpenCR UART1 port (as described [here][appendix_opencr1_0]).
 
 2. Control TurtleBot3 with RC-100.
   - Up / Down : Increase or decrease linear velocity

--- a/_includes/en/platform/turtlebot3/basic_operation_kinetic.md
+++ b/_includes/en/platform/turtlebot3/basic_operation_kinetic.md
@@ -55,7 +55,7 @@ $ source ~/.bashrc
 
 #### [RC100](#rc100)
 
-The settings for [ROBOTIS RC-100B][rc100] controller is included in the OpenCR firmware for TurtleBot3 Burger, Waffle and Waffle Pi. This controller can be used with the Bluetooth module [BT410][bt410]. The TurtleBot3 Waffle Pi includes the RC-100 controller and Bluetooth modules. When using RC-100, it is not necessary to execute a specific node because `turtlebot_core` node creates a `/cmd_vel` topic in the firmware directly connected to OpeCR.
+The settings for [ROBOTIS RC-100B][rc100] controller is included in the OpenCR firmware for TurtleBot3 Burger, Waffle and Waffle Pi. This controller can be used with the Bluetooth module [BT410][bt410]. The TurtleBot3 Waffle Pi includes the RC-100 controller and Bluetooth modules. When using RC-100, it is not necessary to execute a specific node because `turtlebot_core` node creates a `/cmd_vel` topic in the firmware directly connected to OpenCR.
 
 ![](/assets/images/platform/turtlebot3/example/rc100b_with_bt410.png)
 

--- a/_includes/en/platform/turtlebot3/basic_operation_melodic.md
+++ b/_includes/en/platform/turtlebot3/basic_operation_melodic.md
@@ -59,7 +59,7 @@ The settings for [ROBOTIS RC-100B][rc100] controller is included in the OpenCR f
 
 ![](/assets/images/platform/turtlebot3/example/rc100b_with_bt410.png)
 
-1. Connect BT-410 to any of OpenCR UART ports.
+1. Connect BT-410 to OpenCR UART1 port (as described [here][appendix_opencr1_0]).
 
 2. Control TurtleBot3 with RC-100.
   - Up / Down : Increase or decrease linear velocity

--- a/_includes/en/platform/turtlebot3/basic_operation_melodic.md
+++ b/_includes/en/platform/turtlebot3/basic_operation_melodic.md
@@ -55,7 +55,7 @@ $ source ~/.bashrc
 
 #### [RC100](#rc100)
 
-The settings for [ROBOTIS RC-100B][rc100] controller is included in the OpenCR firmware for TurtleBot3 Burger, Waffle and Waffle Pi. This controller can be used with the Bluetooth module [BT410][bt410]. The TurtleBot3 Waffle Pi includes the RC-100 controller and Bluetooth modules. When using RC-100, it is not necessary to execute a specific node because `turtlebot_core` node creates a `/cmd_vel` topic in the firmware directly connected to OpeCR.
+The settings for [ROBOTIS RC-100B][rc100] controller is included in the OpenCR firmware for TurtleBot3 Burger, Waffle and Waffle Pi. This controller can be used with the Bluetooth module [BT410][bt410]. The TurtleBot3 Waffle Pi includes the RC-100 controller and Bluetooth modules. When using RC-100, it is not necessary to execute a specific node because `turtlebot_core` node creates a `/cmd_vel` topic in the firmware directly connected to OpenCR.
 
 ![](/assets/images/platform/turtlebot3/example/rc100b_with_bt410.png)
 

--- a/_includes/en/platform/turtlebot3/basic_operation_noetic.md
+++ b/_includes/en/platform/turtlebot3/basic_operation_noetic.md
@@ -59,7 +59,7 @@ The settings for [ROBOTIS RC-100B][rc100] controller is included in the OpenCR f
 
 ![](/assets/images/platform/turtlebot3/example/rc100b_with_bt410.png)
 
-1. Connect BT-410 to any of OpenCR UART ports.
+1. Connect BT-410 to OpenCR UART1 port (as described [here][appendix_opencr1_0]).
 
 2. Control TurtleBot3 with RC-100.
   - Up / Down : Increase or decrease linear velocity

--- a/_includes/en/platform/turtlebot3/basic_operation_noetic.md
+++ b/_includes/en/platform/turtlebot3/basic_operation_noetic.md
@@ -55,7 +55,7 @@ $ source ~/.bashrc
 
 #### [RC100](#rc100)
 
-The settings for [ROBOTIS RC-100B][rc100] controller is included in the OpenCR firmware for TurtleBot3 Burger, Waffle and Waffle Pi. This controller can be used with the Bluetooth module [BT410][bt410]. The TurtleBot3 Waffle Pi includes the RC-100 controller and Bluetooth modules. When using RC-100, it is not necessary to execute a specific node because `turtlebot_core` node creates a `/cmd_vel` topic in the firmware directly connected to OpeCR.
+The settings for [ROBOTIS RC-100B][rc100] controller is included in the OpenCR firmware for TurtleBot3 Burger, Waffle and Waffle Pi. This controller can be used with the Bluetooth module [BT410][bt410]. The TurtleBot3 Waffle Pi includes the RC-100 controller and Bluetooth modules. When using RC-100, it is not necessary to execute a specific node because `turtlebot_core` node creates a `/cmd_vel` topic in the firmware directly connected to OpenCR.
 
 ![](/assets/images/platform/turtlebot3/example/rc100b_with_bt410.png)
 

--- a/_includes/en/platform/turtlebot3/basic_operation_windows.md
+++ b/_includes/en/platform/turtlebot3/basic_operation_windows.md
@@ -37,11 +37,11 @@ CTRL-C to quit
 
 #### [RC100](#rc100)
 
-The settings for [ROBOTIS RC-100B][rc100] controller is included in the OpenCR firmware for TurtleBot3 Burger, Waffle and Waffle Pi. This controller can be used with the Bluetooth module [BT410][bt410]. The TurtleBot3 Waffle Pi includes the RC-100 controller and Bluetooth modules. When using RC-100, it is not necessary to execute a specific node because `turtlebot_core` node creates a `/cmd_vel` topic in the firmware directly connected to OpeCR.
+The settings for [ROBOTIS RC-100B][rc100] controller is included in the OpenCR firmware for TurtleBot3 Burger, Waffle and Waffle Pi. This controller can be used with the Bluetooth module [BT410][bt410]. The TurtleBot3 Waffle Pi includes the RC-100 controller and Bluetooth modules. When using RC-100, it is not necessary to execute a specific node because `turtlebot_core` node creates a `/cmd_vel` topic in the firmware directly connected to OpenCR.
 
 ![](/assets/images/platform/turtlebot3/example/rc100b_with_bt410.png)
 
-1. Connect BT-410 to any of OpenCR UART ports.
+1. Connect BT-410 to OpenCR UART1 port (as described [here][appendix_opencr1_0]).
 
 2. Control TurtleBot3 with RC-100.
   - Up / Down : Increase or decrease linear velocity

--- a/docs/en/platform/turtlebot3/teleoperation.md
+++ b/docs/en/platform/turtlebot3/teleoperation.md
@@ -85,6 +85,12 @@ The settings for [ROBOTIS RC-100B][rc100] controller is included in the OpenCR f
 
 ![](/assets/images/platform/turtlebot3/example/rc100b_with_bt410.png)
 
+1. Connect BT-410 to OpenCR UART1 port (as described [here][appendix_opencr1_0]).
+
+2. Control TurtleBot3 with RC-100.
+  - Up / Down : Increase or decrease linear velocity
+  - Left / Right : Increase or decrease angular velocity
+
 ## [PS3 Joystick](#ps3-joystick)
 
 **[Remote PC]** Connect PS3 Joystick to the remote PC via Bluetooth or with USB cable.


### PR DESCRIPTION
The driver does not actually read both serial ports. So you have to connect RC100 to the correct one to make it work.

RC100 driver is created here: https://github.com/ROBOTIS-GIT/OpenCR/blob/b913ecf538234104dad40019a13d1a009b7f355d/arduino/opencr_arduino/opencr/libraries/turtlebot3/src/turtlebot3/turtlebot3_controller.cpp#L35

RC100 interpretation of the argument `1` is here: https://github.com/ROBOTIS-GIT/OpenCR/blob/master/arduino/opencr_arduino/opencr/libraries/RC100/RC100.cpp#L45-L49

`Serial2` is marked as `SerialBT1` here: https://github.com/ROBOTIS-GIT/OpenCR/blob/b913ecf538234104dad40019a13d1a009b7f355d/arduino/opencr_arduino/opencr/variants/OpenCR/variant.h#L107

And as I tried, it physically resides on `UART1` as described in https://emanual.robotis.com/docs/en/platform/turtlebot3/appendix_opencr1_0/ .