### PR TITLE
Added TurtleBot3 model specification description

### DIFF
--- a/_includes/en/platform/turtlebot3/autonomous_driving/humble/autonomous_driving_getting_started_humble.md
+++ b/_includes/en/platform/turtlebot3/autonomous_driving/humble/autonomous_driving_getting_started_humble.md
@@ -35,13 +35,13 @@ $ sudo apt install ros-humble-image-transport ros-humble-cv-bridge ros-humble-vi
 
 ### [Setting World Plugin](#setting-world-plugin)
 
-Add an export line to your .bashrc, put your workspace name in {your_ws}. This plugin allows you to animate dynamic environments in your world.  
+Add an export line to your ~/.bashrc, put your workspace name in {your_ws}. This plugin allows you to animate dynamic environments in your world.  
 ``` bash
 $ echo 'export GAZEBO_PLUGIN_PATH=$HOME/{your_ws}/build/turtlebot3_gazebo:$GAZEBO_PLUGIN_PATH' >> ~/.bashrc
 ```
 
-### [Setting TurtleBot3 Model](#setting-turtlebot3-modle)
-Add an export line to your .bashrc. Autorace only supports the burger_cam model.
+### [Setting TurtleBot3 Model](#setting-turtlebot3-model)
+Add an export line to your ~/.bashrc. Autorace only supports the burger_cam model.
 ``` bash
 $ echo 'export TURTLEBOT3_MODEL=burger_cam' >> ~/.bashrc
 ```

--- a/_includes/en/platform/turtlebot3/autonomous_driving/humble/autonomous_driving_getting_started_humble.md
+++ b/_includes/en/platform/turtlebot3/autonomous_driving/humble/autonomous_driving_getting_started_humble.md
@@ -35,7 +35,13 @@ $ sudo apt install ros-humble-image-transport ros-humble-cv-bridge ros-humble-vi
 
 ### [Setting World Plugin](#setting-world-plugin)
 
-1. Add an export line to your .bashrc, put your workspace name in {your_ws}. This plugin allows you to animate dynamic environments in your world.  
+Add an export line to your .bashrc, put your workspace name in {your_ws}. This plugin allows you to animate dynamic environments in your world.  
 ``` bash
 $ echo 'export GAZEBO_PLUGIN_PATH=$HOME/{your_ws}/build/turtlebot3_gazebo:$GAZEBO_PLUGIN_PATH' >> ~/.bashrc
+```
+
+### [Setting TurtleBot3 Model](#setting-turtlebot3-modle)
+Add an export line to your .bashrc. Autorace only supports the burger_cam model.
+``` bash
+$ echo 'export TURTLEBOT3_MODEL=burger_cam' >> ~/.bashrc
 ```


### PR DESCRIPTION
Added a note to specify a turtlebot model for Autorace. Since the existing burger model does not have a camera, you must use the model with the camera added.

https://github.com/ROBOTIS-GIT/turtlebot3_autorace/issues/62#issue-2949122551