### PR TITLE
Add installation simulation package for TB3 manipulation

### DIFF
--- a/_includes/en/platform/turtlebot3/manipulation/manipulation_simulation_humble.md
+++ b/_includes/en/platform/turtlebot3/manipulation/manipulation_simulation_humble.md
@@ -1,14 +1,24 @@
 
 Simulate the TurtleBot3 Manipulation using Gazebo by following the instructions below.
 
+### [Install Simulation Package](#install-simulation-package)
+
+Install the packages for TurtleBot3 Manipulation Gazebo simulation.
+
+**[Remote PC]**  
+```bash
+$ cd ~/turtlebot3_ws/src/
+$ git clone -b humble https://github.com/ROBOTIS-GIT/turtlebot3_simulations.git
+$ cd ~/turtlebot3_ws && colcon build --symlink-install
+```
+
 ### [How to Run Gazebo](#how-to-run-gazebo)
 
 Bringup the TurtleBot3 with OpenMANIPULATOR-X in Gazebo world with the following command.
 
-**[Remote PC]** 
-
+**[Remote PC]**  
 ```bash
-$ ros2 launch turtlebot3_manipulation_bringup gazebo.launch.py
+$ ros2 launch turtlebot3_manipulation_gazebo gazebo.launch.py
 ```
 
 ![](/assets/images/platform/turtlebot3/manipulation/tb3_manipulation_ros2_gazebo.png)
@@ -21,7 +31,7 @@ $ ros2 launch turtlebot3_manipulation_bringup gazebo.launch.py
 In order to run with RViz, append the `start_rviz` parameter as below.  
 **[Remote PC]**  
 ```bash
-$ ros2 launch turtlebot3_manipulation_bringup gazebo.launch.py start_rviz:=true
+$ ros2 launch turtlebot3_manipulation_gazebo gazebo.launch.py start_rviz:=true
 ```
 {% endcapture %}
 <div class="notice--info">{{ tip_01 | markdownify }}</div>

--- a/_includes/en/platform/turtlebot3/manipulation/manipulation_software_setup_humble.md
+++ b/_includes/en/platform/turtlebot3/manipulation/manipulation_software_setup_humble.md
@@ -8,24 +8,24 @@
 
 1. Connect to the **TurtleBot3 SBC** using the ssh command below.   
 **[Remote PC]**  
-  ```bash
-  $ ssh ubuntu@{IP_ADDRESS_OF_TURTLEBOT3}
-  ```
+```bash
+$ ssh ubuntu@{IP_ADDRESS_OF_TURTLEBOT3}
+```
 2. Install the packages for TurtleBot3 Manipulation.  
 **[TurtleBot3 SBC]**  
-  ```bash
-  $ sudo apt install ros-humble-hardware-interface ros-humble-xacro ros-humble-ros2-control ros-humble-ros2-controllers ros-humble-gripper-controllers
-  $ cd ~/turtlebot3_ws/src/
-  $ git clone -b humble https://github.com/ROBOTIS-GIT/turtlebot3_manipulation.git
-  $ cd ~/turtlebot3_ws && colcon build --symlink-install
-  ```
+```bash
+$ sudo apt install ros-humble-hardware-interface ros-humble-xacro ros-humble-ros2-control ros-humble-ros2-controllers ros-humble-gripper-controllers
+$ cd ~/turtlebot3_ws/src/
+$ git clone -b humble https://github.com/ROBOTIS-GIT/turtlebot3_manipulation.git
+$ cd ~/turtlebot3_ws && colcon build --symlink-install
+```
 
 
 1. Open a terminal on the **Remote PC** and install the required packages using the following commands.  
 **[Remote PC]**  
-  ```bash
-  $ sudo apt install ros-humble-dynamixel-sdk ros-humble-ros2-control ros-humble-ros2-controllers ros-humble-gripper-controllers ros-humble-moveit*
-  $ cd ~/turtlebot3_ws/src/
-  $ git clone -b humble https://github.com/ROBOTIS-GIT/turtlebot3_manipulation.git
-  $ cd ~/turtlebot3_ws && colcon build --symlink-install
-  ```
+```bash
+$ sudo apt install ros-humble-dynamixel-sdk ros-humble-ros2-control ros-humble-ros2-controllers ros-humble-gripper-controllers ros-humble-moveit*
+$ cd ~/turtlebot3_ws/src/
+$ git clone -b humble https://github.com/ROBOTIS-GIT/turtlebot3_manipulation.git
+$ cd ~/turtlebot3_ws && colcon build --symlink-install
+```


### PR DESCRIPTION
Gazebo simulations for turtlebot3 manipulation have been moved to the turtlebot3_simulations repository, so this is a corresponding e-manual change.

## Related PRs
https://github.com/ROBOTIS-GIT/turtlebot3_simulations/pull/239#issue-3108889359
https://github.com/ROBOTIS-GIT/turtlebot3_manipulation/pull/86#issue-3108736458
https://github.com/ROBOTIS-GIT/turtlebot3_home_service_challenge/pull/34#issue-3108710986