### PR TITLE
Make workspace paths consistent by using absolute paths (~/colcon_ws/src, ~/ros2_ws/src)

### DIFF
--- a/_includes/en/platform/openmanipulator_x/quick_start_guide/quickstart_humble_ros_packages.md
+++ b/_includes/en/platform/openmanipulator_x/quick_start_guide/quickstart_humble_ros_packages.md
@@ -18,7 +18,7 @@ $ sudo apt install \
 ```
 
 ```bash
-$ mkdir -p colcon_ws/src
+$ mkdir -p ~/colcon_ws/src
 $ cd ~/colcon_ws/src/
 $ git clone -b humble https://github.com/ROBOTIS-GIT/DynamixelSDK.git
 $ git clone -b humble https://github.com/ROBOTIS-GIT/open_manipulator.git

--- a/_includes/en/platform/openmanipulator_x/quick_start_guide/quickstart_jazzy_ros_packages.md
+++ b/_includes/en/platform/openmanipulator_x/quick_start_guide/quickstart_jazzy_ros_packages.md
@@ -18,7 +18,7 @@ This will ensure you have the latest and most compatible version for your system
 #### Clone the Repository
 
 ```bash
-$ mkdir -p ros2_ws/src
+$ mkdir -p ~/ros2_ws/src
 $ cd ~/ros2_ws/src
 $ git clone -b jazzy https://github.com/ROBOTIS-GIT/DynamixelSDK.git && \
   git clone -b jazzy https://github.com/ROBOTIS-GIT/dynamixel_interfaces.git && \


### PR DESCRIPTION
This commit updates the documentation to use absolute paths (~/colcon_ws/src and ~/ros2_ws/src) instead of relative paths (colcon_ws/src and ros2_ws/src) when creating the workspace directory. This helps avoid potential issues when the commands are run from unexpected locations.